### PR TITLE
feat(ci): add police filing build arg to landing page workflow

### DIFF
--- a/.github/workflows/fastgpt-home-image.yml
+++ b/.github/workflows/fastgpt-home-image.yml
@@ -72,6 +72,7 @@ jobs:
             NEXT_PUBLIC_HOME_URL=${{ secrets.NEXT_PUBLIC_HOME_URL }}
             NEXT_PUBLIC_USER_URL=${{ secrets.NEXT_PUBLIC_USER_URL }}
             NEXT_PUBLIC_FILING_ADDRESS=${{ secrets.NEXT_PUBLIC_FILING_ADDRESS }}
+            NEXT_PUBLIC_POLICE_FILING=${{ secrets.NEXT_PUBLIC_POLICE_FILING }}
 
     outputs:
       tags: ${{ steps.datetime.outputs.datetime }}


### PR DESCRIPTION
Add NEXT_PUBLIC_POLICE_FILING environment variable as build argument in fastgpt-home-image workflow for configuring police filing information on the landing page.