### PR TITLE
feat: add zh-Hant locale

### DIFF
--- a/public/ar/llms.txt
+++ b/public/ar/llms.txt
@@ -3,5 +3,6 @@
 This locale uses the English LLM context.
 
 - English LLM Context: https://fastgpt.io/en/llms.txt
-- Chinese LLM Context: https://fastgpt.io/zh/llms.txt
+- Simplified Chinese LLM Context: https://fastgpt.io/zh/llms.txt
+- Traditional Chinese LLM Context: https://fastgpt.io/zh-hant/llms.txt
 - Localized Page: https://fastgpt.io/ar

--- a/public/en/llms.txt
+++ b/public/en/llms.txt
@@ -11,15 +11,17 @@ FastGPT is designed for enterprise knowledge base Q&A, AI customer service, inte
 - Cloud Service: https://cloud.fastgpt.io
 - Pricing: https://fastgpt.io/en/price
 - FAQ: https://fastgpt.io/en/faq
-- Chinese FAQ: https://fastgpt.io/zh/faq
-- Chinese LLM Context: https://fastgpt.io/zh/llms.txt
+- Simplified Chinese FAQ: https://fastgpt.io/zh/faq
+- Simplified Chinese LLM Context: https://fastgpt.io/zh/llms.txt
+- Traditional Chinese LLM Context: https://fastgpt.io/zh-hant/llms.txt
 - Enterprise Appliance: https://fastgpt.io/zh/enterprise
 - GitHub: https://github.com/labring/FastGPT
 
 ## Localized Entry Points
 
 - English: https://fastgpt.io/en
-- 中文: https://fastgpt.io/zh
+- 简体中文: https://fastgpt.io/zh
+- 繁體中文: https://fastgpt.io/zh-hant
 - 日本語: https://fastgpt.io/ja
 - العربية: https://fastgpt.io/ar
 - Tiếng Việt: https://fastgpt.io/vi
@@ -27,7 +29,7 @@ FastGPT is designed for enterprise knowledge base Q&A, AI customer service, inte
 - Bahasa Indonesia: https://fastgpt.io/id
 - Bahasa Melayu: https://fastgpt.io/ms
 
-The Japanese, Arabic, Vietnamese, Thai, Indonesian, and Malay pages use this English LLM context file. Chinese uses https://fastgpt.io/zh/llms.txt.
+The Japanese, Arabic, Vietnamese, Thai, Indonesian, and Malay pages use this English LLM context file. Chinese uses https://fastgpt.io/zh/llms.txt, and Traditional Chinese uses https://fastgpt.io/zh-hant/llms.txt.
 
 ## Core Features
 
@@ -44,6 +46,9 @@ FastGPT works with model services compatible with the OpenAI API format. Teams c
 FastGPT offers cloud service, open-source self-hosting, and enterprise private deployment or appliance options. The open-source edition is suitable for self-hosting and secondary development; the cloud service is suitable for fast adoption; enterprise deployment is suitable for stricter data security and internal network requirements.
 
 ## Localized Summaries
+
+### 繁體中文
+FastGPT 是開源的企業級 AI Agent 構建平台，結合知識庫、Agentic RAG、可視化工作流與多模型接入。繁體中文頁面面向使用繁體中文的企業軟體採購者，提供產品能力、雲服務、開源自部署、私有化部署與價格方案說明。
 
 ### 日本語
 FastGPT は、エンタープライズ向け AI Agent、ナレッジベース、RAG、ビジュアルワークフローを構築するためのオープンソースプラットフォームです。日本語ページでは、料金、導入シナリオ、クラウド利用、セルフホスト、エンタープライズ一体機の情報を日本の SaaS 利用者向けの表現で提供しています。

--- a/public/id/llms.txt
+++ b/public/id/llms.txt
@@ -3,5 +3,6 @@
 This locale uses the English LLM context.
 
 - English LLM Context: https://fastgpt.io/en/llms.txt
-- Chinese LLM Context: https://fastgpt.io/zh/llms.txt
+- Simplified Chinese LLM Context: https://fastgpt.io/zh/llms.txt
+- Traditional Chinese LLM Context: https://fastgpt.io/zh-hant/llms.txt
 - Localized Page: https://fastgpt.io/id

--- a/public/ja/llms.txt
+++ b/public/ja/llms.txt
@@ -3,5 +3,6 @@
 This locale uses the English LLM context.
 
 - English LLM Context: https://fastgpt.io/en/llms.txt
-- Chinese LLM Context: https://fastgpt.io/zh/llms.txt
+- Simplified Chinese LLM Context: https://fastgpt.io/zh/llms.txt
+- Traditional Chinese LLM Context: https://fastgpt.io/zh-hant/llms.txt
 - Localized Page: https://fastgpt.io/ja

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -11,15 +11,17 @@ FastGPT is designed for enterprise knowledge base Q&A, AI customer service, inte
 - Cloud Service: https://cloud.fastgpt.io
 - Pricing: https://fastgpt.io/en/price
 - FAQ: https://fastgpt.io/en/faq
-- Chinese FAQ: https://fastgpt.io/zh/faq
-- Chinese LLM Context: https://fastgpt.io/zh/llms.txt
+- Simplified Chinese FAQ: https://fastgpt.io/zh/faq
+- Simplified Chinese LLM Context: https://fastgpt.io/zh/llms.txt
+- Traditional Chinese LLM Context: https://fastgpt.io/zh-hant/llms.txt
 - Enterprise Appliance: https://fastgpt.io/zh/enterprise
 - GitHub: https://github.com/labring/FastGPT
 
 ## Localized Entry Points
 
 - English: https://fastgpt.io/en
-- 中文: https://fastgpt.io/zh
+- 简体中文: https://fastgpt.io/zh
+- 繁體中文: https://fastgpt.io/zh-hant
 - 日本語: https://fastgpt.io/ja
 - العربية: https://fastgpt.io/ar
 - Tiếng Việt: https://fastgpt.io/vi
@@ -27,7 +29,7 @@ FastGPT is designed for enterprise knowledge base Q&A, AI customer service, inte
 - Bahasa Indonesia: https://fastgpt.io/id
 - Bahasa Melayu: https://fastgpt.io/ms
 
-The Japanese, Arabic, Vietnamese, Thai, Indonesian, and Malay pages use this English LLM context file. Chinese uses https://fastgpt.io/zh/llms.txt.
+The Japanese, Arabic, Vietnamese, Thai, Indonesian, and Malay pages use this English LLM context file. Chinese uses https://fastgpt.io/zh/llms.txt, and Traditional Chinese uses https://fastgpt.io/zh-hant/llms.txt.
 
 ## Core Features
 
@@ -44,6 +46,9 @@ FastGPT works with model services compatible with the OpenAI API format. Teams c
 FastGPT offers cloud service, open-source self-hosting, and enterprise private deployment or appliance options. The open-source edition is suitable for self-hosting and secondary development; the cloud service is suitable for fast adoption; enterprise deployment is suitable for stricter data security and internal network requirements.
 
 ## Localized Summaries
+
+### 繁體中文
+FastGPT 是開源的企業級 AI Agent 構建平台，結合知識庫、Agentic RAG、可視化工作流與多模型接入。繁體中文頁面面向使用繁體中文的企業軟體採購者，提供產品能力、雲服務、開源自部署、私有化部署與價格方案說明。
 
 ### 日本語
 FastGPT は、エンタープライズ向け AI Agent、ナレッジベース、RAG、ビジュアルワークフローを構築するためのオープンソースプラットフォームです。日本語ページでは、料金、導入シナリオ、クラウド利用、セルフホスト、エンタープライズ一体機の情報を日本の SaaS 利用者向けの表現で提供しています。

--- a/public/ms/llms.txt
+++ b/public/ms/llms.txt
@@ -3,5 +3,6 @@
 This locale uses the English LLM context.
 
 - English LLM Context: https://fastgpt.io/en/llms.txt
-- Chinese LLM Context: https://fastgpt.io/zh/llms.txt
+- Simplified Chinese LLM Context: https://fastgpt.io/zh/llms.txt
+- Traditional Chinese LLM Context: https://fastgpt.io/zh-hant/llms.txt
 - Localized Page: https://fastgpt.io/ms

--- a/public/th/llms.txt
+++ b/public/th/llms.txt
@@ -3,5 +3,6 @@
 This locale uses the English LLM context.
 
 - English LLM Context: https://fastgpt.io/en/llms.txt
-- Chinese LLM Context: https://fastgpt.io/zh/llms.txt
+- Simplified Chinese LLM Context: https://fastgpt.io/zh/llms.txt
+- Traditional Chinese LLM Context: https://fastgpt.io/zh-hant/llms.txt
 - Localized Page: https://fastgpt.io/th

--- a/public/vi/llms.txt
+++ b/public/vi/llms.txt
@@ -3,5 +3,6 @@
 This locale uses the English LLM context.
 
 - English LLM Context: https://fastgpt.io/en/llms.txt
-- Chinese LLM Context: https://fastgpt.io/zh/llms.txt
+- Simplified Chinese LLM Context: https://fastgpt.io/zh/llms.txt
+- Traditional Chinese LLM Context: https://fastgpt.io/zh-hant/llms.txt
 - Localized Page: https://fastgpt.io/vi

--- a/public/zh-hant/llms.txt
+++ b/public/zh-hant/llms.txt
@@ -1,0 +1,68 @@
+# FastGPT
+
+> FastGPT 是開源的企業級 AI Agent 構建平台，提供知識庫、Agentic RAG、可視化工作流、MCP 工具與多模型接入能力，協助團隊構建安全、可控、可落地的企業級 AI 應用。
+
+FastGPT 面向企業知識庫問答、AI 客服、內部助手、流程自動化與產業智能體場景。它支援透過文件、網頁、手動問答與 API 資料構建知識庫，並透過可視化工作流編排模型呼叫、檢索、資料庫查詢、HTTP 請求、條件分支與外部系統整合。
+
+## 關鍵連結
+
+- 官網：https://fastgpt.io
+- 國內文件：https://doc.fastgpt.cn
+- 國際文件：https://doc.fastgpt.io
+- 雲服務：https://cloud.fastgpt.io
+- 定價：https://fastgpt.io/zh-hant/price
+- FAQ：https://fastgpt.io/zh/faq
+- 簡體中文 LLM Context：https://fastgpt.io/zh/llms.txt
+- 英文 LLM Context：https://fastgpt.io/en/llms.txt
+- 企業一體機：https://fastgpt.io/zh/enterprise
+- GitHub：https://github.com/labring/FastGPT
+
+## 核心能力
+
+### 企業知識庫與 Agentic RAG
+FastGPT 支援 Word、PDF、Excel、Markdown、網頁連結等資料匯入，提供文字預處理、向量化、QA 分割、檢索測試與引用編輯能力，適合構建企業內部知識庫、客服知識庫與產業問答系統。
+
+### 可視化 AI 工作流
+FastGPT 提供可視化工作流編排能力，可以組合模型呼叫、知識庫檢索、條件判斷、HTTP 請求、資料庫查詢與外部工具，構建複雜的 AI Agent 和自動化業務流程。
+
+### 多模型與 OpenAI 相容 API
+FastGPT 可以接入與 OpenAI API 對齊的模型服務，並可透過 One API 等閘道統一管理多模型呼叫，適配 GPT、Claude、文心、通義、DeepSeek 與私有化模型等場景。
+
+### 雲服務、開源版與私有化部署
+FastGPT 提供雲服務、開源自部署與企業級私有化/一體機方案。開源版適合自主部署與二次開發；雲服務適合快速使用；企業一體機適合對資料安全、內網部署、硬體交付與服務支援有要求的組織。
+
+## 適用場景
+
+- 企業知識庫問答
+- AI 智能客服
+- 內部員工助手
+- 文件檢索與問答
+- 銷售、售後、營運自動化
+- 資料查詢與業務流程編排
+- 產業智能體和企業級 Agent 平台
+
+## 商業授權邊界
+
+FastGPT 開源版可以用於商業化場景，例如作為應用後端能力或企業內部應用開發平台。若涉及多租戶 SaaS 服務、移除或修改 LOGO 與版權資訊等場景，需要聯繫作者取得商業授權。
+
+## FAQ
+
+### FastGPT 是什麼？
+FastGPT 是開源的企業級 AI Agent 構建平台，提供知識庫、RAG、工作流與模型接入能力，用於構建企業 AI 應用。
+
+### FastGPT 可以匯入哪些文件？
+FastGPT 支援 Word、PDF、Excel、Markdown、網頁連結等格式，並支援自動文字預處理、向量化與 QA 分割。
+
+### FastGPT 可以接入哪些模型？
+只要模型 API 與 OpenAI 介面相容，通常都可以接入 FastGPT。也可以透過模型閘道統一管理不同模型。
+
+### FastGPT 適合私有化部署嗎？
+適合。FastGPT 支援開源自部署，也提供企業私有化與軟硬一體機方案，適用於資料安全與內網部署要求較高的企業。
+
+FAQ 詳細頁目前僅維護英文與簡體中文版本；繁體中文定價頁內含本地化價格 FAQ。
+
+## 聯繫方式
+
+- 郵箱：Dennis@sealos.io
+- GitHub：https://github.com/labring/FastGPT
+- 官網：https://fastgpt.io

--- a/public/zh/llms.txt
+++ b/public/zh/llms.txt
@@ -12,6 +12,7 @@ FastGPT 面向企业知识库问答、AI 客服、内部助手、流程自动化
 - 云服务：https://cloud.fastgpt.io
 - 定价：https://fastgpt.io/zh/price
 - FAQ：https://fastgpt.io/zh/faq
+- 繁体中文 LLM Context：https://fastgpt.io/zh-hant/llms.txt
 - 英文 LLM Context：https://fastgpt.io/en/llms.txt
 - 企业一体机：https://fastgpt.io/zh/enterprise
 - GitHub：https://github.com/labring/FastGPT

--- a/scripts/clean-faq-rsc.js
+++ b/scripts/clean-faq-rsc.js
@@ -25,7 +25,7 @@ function cleanDir(dir) {
       if (entry.name.startsWith('__next')) continue;
       // Check if this is a FAQ detail directory (contains __next.*.txt files)
       const subEntries = fs.readdirSync(fullPath);
-      const hasRscFiles = subEntries.some(f => f.startsWith('__next.') && f.endsWith('.txt'));
+      const hasRscFiles = subEntries.some((f) => f.startsWith('__next.') && f.endsWith('.txt'));
       if (hasRscFiles) {
         // Remove RSC txt files, keep the directory if it has other content
         for (const sub of subEntries) {
@@ -59,7 +59,7 @@ function cleanDir(dir) {
 }
 
 // Clean FAQ directories for all locales
-const locales = ['en', 'zh', 'ja', 'ar', 'vi', 'th', 'id', 'ms'];
+const locales = ['en', 'zh-hant', 'zh', 'ja', 'ar', 'vi', 'th', 'id', 'ms'];
 for (const locale of locales) {
   const faqDir = path.join(outDir, locale, 'faq');
   if (fs.existsSync(faqDir)) {

--- a/scripts/clean-locales.js
+++ b/scripts/clean-locales.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const LOCALES = ['zh', 'en', 'ja', 'ar', 'vi', 'th', 'id', 'ms'];
+const LOCALES = ['zh', 'zh-hant', 'en', 'ja', 'ar', 'vi', 'th', 'id', 'ms'];
 const LOCALE_DIR = path.join(process.cwd(), 'src/locales');
 
 const ALLOWED_TOP_LEVEL_KEYS = new Set([
@@ -28,9 +28,13 @@ const ALLOWED_PRICING_KEYS = new Set([
   'allFeatures',
   'moreFeatures',
   'moreFeaturesLink',
+  'monthPriceFormat',
+  'monthUnit',
   'chooseVersion',
   'freeUse',
   'monthly',
+  'yearPriceFormat',
+  'yearUnit',
   'aiCredits',
   'faq'
 ]);
@@ -62,7 +66,9 @@ function listLeafPaths(value, prefix = '') {
   }
 
   if (value && typeof value === 'object') {
-    return Object.keys(value).flatMap((key) => listLeafPaths(value[key], prefix ? `${prefix}.${key}` : key));
+    return Object.keys(value).flatMap((key) =>
+      listLeafPaths(value[key], prefix ? `${prefix}.${key}` : key)
+    );
   }
 
   return [prefix];

--- a/scripts/copy-root-index.js
+++ b/scripts/copy-root-index.js
@@ -5,17 +5,26 @@
 const fs = require('fs');
 const path = require('path');
 
-// Normalize locale to base language code (zh-CN → zh, en-US → en, etc.)
+// Normalize locale to the static route code (zh-CN → zh, zh-Hant → zh-hant, etc.)
 function normalizeLocale(locale) {
   if (!locale) return 'en';
-  if (locale.startsWith('zh')) return 'zh';
-  if (locale.startsWith('en')) return 'en';
-  if (locale.startsWith('ja')) return 'ja';
-  if (locale.startsWith('ar')) return 'ar';
-  if (locale.startsWith('vi')) return 'vi';
-  if (locale.startsWith('th')) return 'th';
-  if (locale.startsWith('id')) return 'id';
-  if (locale.startsWith('ms')) return 'ms';
+  const normalized = String(locale).toLowerCase().replace(/_/g, '-');
+  if (
+    normalized.startsWith('zh-hant') ||
+    normalized.startsWith('zh-tw') ||
+    normalized.startsWith('zh-hk') ||
+    normalized.startsWith('zh-mo')
+  ) {
+    return 'zh-hant';
+  }
+  if (normalized.startsWith('zh')) return 'zh';
+  if (normalized.startsWith('en')) return 'en';
+  if (normalized.startsWith('ja')) return 'ja';
+  if (normalized.startsWith('ar')) return 'ar';
+  if (normalized.startsWith('vi')) return 'vi';
+  if (normalized.startsWith('th')) return 'th';
+  if (normalized.startsWith('id')) return 'id';
+  if (normalized.startsWith('ms')) return 'ms';
   return 'en';
 }
 

--- a/scripts/fix-html-lang.js
+++ b/scripts/fix-html-lang.js
@@ -8,6 +8,7 @@ const path = require('path');
 
 const localeConfigs = [
   { code: 'en', htmlLang: 'en-US', dir: 'ltr' },
+  { code: 'zh-hant', htmlLang: 'zh-Hant', dir: 'ltr' },
   { code: 'zh', htmlLang: 'zh-CN', dir: 'ltr' },
   { code: 'ja', htmlLang: 'ja-JP', dir: 'ltr' },
   { code: 'ar', htmlLang: 'ar-SA', dir: 'rtl' },
@@ -23,7 +24,15 @@ const defaultLocale = normalizeLocale(process.env.NEXT_PUBLIC_DEFAULT_LOCALE || 
 
 function normalizeLocale(locale) {
   if (!locale) return 'en';
-  const normalized = String(locale).toLowerCase();
+  const normalized = String(locale).toLowerCase().replace(/_/g, '-');
+  if (
+    normalized.startsWith('zh-hant') ||
+    normalized.startsWith('zh-tw') ||
+    normalized.startsWith('zh-hk') ||
+    normalized.startsWith('zh-mo')
+  ) {
+    return 'zh-hant';
+  }
   for (const config of localeConfigs) {
     if (normalized.startsWith(config.code)) return config.code;
   }

--- a/scripts/generate-llms.js
+++ b/scripts/generate-llms.js
@@ -17,6 +17,7 @@ const links = isCn
       documentation: 'https://doc.fastgpt.cn',
       cloud: 'https://cloud.fastgpt.cn',
       pricingEn: 'https://fastgpt.cn/en/price',
+      pricingZhHant: 'https://fastgpt.cn/zh-hant/price',
       pricingZh: 'https://fastgpt.cn/zh/price',
       faqEn: 'https://fastgpt.cn/en/faq',
       faqZh: 'https://fastgpt.cn/zh/faq',
@@ -27,6 +28,7 @@ const links = isCn
       documentation: 'https://doc.fastgpt.io',
       cloud: 'https://cloud.fastgpt.io',
       pricingEn: 'https://fastgpt.io/en/price',
+      pricingZhHant: 'https://fastgpt.io/zh-hant/price',
       pricingZh: 'https://fastgpt.io/zh/price',
       faqEn: 'https://fastgpt.io/en/faq',
       faqZh: 'https://fastgpt.io/zh/faq',
@@ -46,15 +48,17 @@ FastGPT is designed for enterprise knowledge base Q&A, AI customer service, inte
 - Cloud Service: ${links.cloud}
 - Pricing: ${links.pricingEn}
 - FAQ: ${links.faqEn}
-- Chinese FAQ: ${links.faqZh}
-- Chinese LLM Context: ${baseUrl}/zh/llms.txt
+- Simplified Chinese FAQ: ${links.faqZh}
+- Simplified Chinese LLM Context: ${baseUrl}/zh/llms.txt
+- Traditional Chinese LLM Context: ${baseUrl}/zh-hant/llms.txt
 - Enterprise Appliance: ${links.enterprise}
 - GitHub: https://github.com/labring/FastGPT
 
 ## Localized Entry Points
 
 - English: ${baseUrl}/en
-- 中文: ${baseUrl}/zh
+- 简体中文: ${baseUrl}/zh
+- 繁體中文: ${baseUrl}/zh-hant
 - 日本語: ${baseUrl}/ja
 - العربية: ${baseUrl}/ar
 - Tiếng Việt: ${baseUrl}/vi
@@ -62,7 +66,7 @@ FastGPT is designed for enterprise knowledge base Q&A, AI customer service, inte
 - Bahasa Indonesia: ${baseUrl}/id
 - Bahasa Melayu: ${baseUrl}/ms
 
-The Japanese, Arabic, Vietnamese, Thai, Indonesian, and Malay pages use this English LLM context file. Chinese uses ${baseUrl}/zh/llms.txt.
+The Japanese, Arabic, Vietnamese, Thai, Indonesian, and Malay pages use this English LLM context file. Chinese uses ${baseUrl}/zh/llms.txt, and Traditional Chinese uses ${baseUrl}/zh-hant/llms.txt.
 
 ## Core Features
 
@@ -79,6 +83,9 @@ FastGPT works with model services compatible with the OpenAI API format. Teams c
 FastGPT offers cloud service, open-source self-hosting, and enterprise private deployment or appliance options. The open-source edition is suitable for self-hosting and secondary development; the cloud service is suitable for fast adoption; enterprise deployment is suitable for stricter data security and internal network requirements.
 
 ## Localized Summaries
+
+### 繁體中文
+FastGPT 是開源的企業級 AI Agent 構建平台，結合知識庫、Agentic RAG、可視化工作流與多模型接入。繁體中文頁面面向使用繁體中文的企業軟體採購者，提供產品能力、雲服務、開源自部署、私有化部署與價格方案說明。
 
 ### 日本語
 FastGPT は、エンタープライズ向け AI Agent、ナレッジベース、RAG、ビジュアルワークフローを構築するためのオープンソースプラットフォームです。日本語ページでは、料金、導入シナリオ、クラウド利用、セルフホスト、エンタープライズ一体機の情報を日本の SaaS 利用者向けの表現で提供しています。
@@ -149,6 +156,7 @@ FastGPT 面向企业知识库问答、AI 客服、内部助手、流程自动化
 - 云服务：${links.cloud}
 - 定价：${links.pricingZh}
 - FAQ：${links.faqZh}
+- 繁体中文 LLM Context：${baseUrl}/zh-hant/llms.txt
 - 英文 LLM Context：${baseUrl}/en/llms.txt
 - 企业一体机：${links.enterprise}
 - GitHub：https://github.com/labring/FastGPT
@@ -202,6 +210,76 @@ FastGPT 支持 Word、PDF、Excel、Markdown、网页链接等格式，并支持
 - 官网：${links.website}
 `;
 
+const traditionalChineseContent = `# FastGPT
+
+> FastGPT 是開源的企業級 AI Agent 構建平台，提供知識庫、Agentic RAG、可視化工作流、MCP 工具與多模型接入能力，協助團隊構建安全、可控、可落地的企業級 AI 應用。
+
+FastGPT 面向企業知識庫問答、AI 客服、內部助手、流程自動化與產業智能體場景。它支援透過文件、網頁、手動問答與 API 資料構建知識庫，並透過可視化工作流編排模型呼叫、檢索、資料庫查詢、HTTP 請求、條件分支與外部系統整合。
+
+## 關鍵連結
+
+- 官網：${links.website}
+- 國內文件：https://doc.fastgpt.cn
+- 國際文件：https://doc.fastgpt.io
+- 雲服務：${links.cloud}
+- 定價：${links.pricingZhHant}
+- FAQ：${links.faqZh}
+- 簡體中文 LLM Context：${baseUrl}/zh/llms.txt
+- 英文 LLM Context：${baseUrl}/en/llms.txt
+- 企業一體機：${links.enterprise}
+- GitHub：https://github.com/labring/FastGPT
+
+## 核心能力
+
+### 企業知識庫與 Agentic RAG
+FastGPT 支援 Word、PDF、Excel、Markdown、網頁連結等資料匯入，提供文字預處理、向量化、QA 分割、檢索測試與引用編輯能力，適合構建企業內部知識庫、客服知識庫與產業問答系統。
+
+### 可視化 AI 工作流
+FastGPT 提供可視化工作流編排能力，可以組合模型呼叫、知識庫檢索、條件判斷、HTTP 請求、資料庫查詢與外部工具，構建複雜的 AI Agent 和自動化業務流程。
+
+### 多模型與 OpenAI 相容 API
+FastGPT 可以接入與 OpenAI API 對齊的模型服務，並可透過 One API 等閘道統一管理多模型呼叫，適配 GPT、Claude、文心、通義、DeepSeek 與私有化模型等場景。
+
+### 雲服務、開源版與私有化部署
+FastGPT 提供雲服務、開源自部署與企業級私有化/一體機方案。開源版適合自主部署與二次開發；雲服務適合快速使用；企業一體機適合對資料安全、內網部署、硬體交付與服務支援有要求的組織。
+
+## 適用場景
+
+- 企業知識庫問答
+- AI 智能客服
+- 內部員工助手
+- 文件檢索與問答
+- 銷售、售後、營運自動化
+- 資料查詢與業務流程編排
+- 產業智能體和企業級 Agent 平台
+
+## 商業授權邊界
+
+FastGPT 開源版可以用於商業化場景，例如作為應用後端能力或企業內部應用開發平台。若涉及多租戶 SaaS 服務、移除或修改 LOGO 與版權資訊等場景，需要聯繫作者取得商業授權。
+
+## FAQ
+
+### FastGPT 是什麼？
+FastGPT 是開源的企業級 AI Agent 構建平台，提供知識庫、RAG、工作流與模型接入能力，用於構建企業 AI 應用。
+
+### FastGPT 可以匯入哪些文件？
+FastGPT 支援 Word、PDF、Excel、Markdown、網頁連結等格式，並支援自動文字預處理、向量化與 QA 分割。
+
+### FastGPT 可以接入哪些模型？
+只要模型 API 與 OpenAI 介面相容，通常都可以接入 FastGPT。也可以透過模型閘道統一管理不同模型。
+
+### FastGPT 適合私有化部署嗎？
+適合。FastGPT 支援開源自部署，也提供企業私有化與軟硬一體機方案，適用於資料安全與內網部署要求較高的企業。
+
+FAQ 詳細頁目前僅維護英文與簡體中文版本；繁體中文定價頁內含本地化價格 FAQ。
+
+## 聯繫方式
+
+- 郵箱：Dennis@sealos.io
+- GitHub：https://github.com/labring/FastGPT
+- 官網：${links.website}
+`;
+
 function writeText(relativePath, content) {
   const outputPath = path.join(publicDir, relativePath);
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
@@ -215,13 +293,15 @@ function englishAliasContent(locale) {
 This locale uses the English LLM context.
 
 - English LLM Context: ${baseUrl}/en/llms.txt
-- Chinese LLM Context: ${baseUrl}/zh/llms.txt
+- Simplified Chinese LLM Context: ${baseUrl}/zh/llms.txt
+- Traditional Chinese LLM Context: ${baseUrl}/zh-hant/llms.txt
 - Localized Page: ${baseUrl}/${locale}
 `;
 }
 
 writeText('llms.txt', englishContent);
 writeText('en/llms.txt', englishContent);
+writeText('zh-hant/llms.txt', traditionalChineseContent);
 writeText('zh/llms.txt', chineseContent);
 
 for (const locale of englishFallbackLocales) {

--- a/src/app/[lang]/price/page.tsx
+++ b/src/app/[lang]/price/page.tsx
@@ -10,6 +10,7 @@ import { Metadata } from 'next';
 
 const titleMap: Record<string, string> = {
   zh: 'FastGPT 定价 - 选择适合你的方案',
+  'zh-hant': 'FastGPT 定價 - 選擇適合你的方案',
   en: 'FastGPT Pricing - Choose Your Plan',
   ja: 'FastGPT 料金プラン - あなたに最適なプランを選択',
   ar: 'أسعار FastGPT - اختر الخطة المناسبة',
@@ -21,6 +22,8 @@ const titleMap: Record<string, string> = {
 
 const descMap: Record<string, string> = {
   zh: 'FastGPT 提供免费开源版和多种付费方案，满足个人开发者到企业级用户的不同需求。查看定价详情，选择最适合你的 AI Agent 构建方案。',
+  'zh-hant':
+    'FastGPT 提供免費開源版和多種付費方案，滿足個人開發者到企業級使用者的不同需求。查看定價詳情，選擇最適合你的 AI Agent 構建方案。',
   en: 'FastGPT offers a free open-source version and multiple paid plans for individual developers to enterprise users. View pricing details and choose the best AI Agent building plan.',
   ja: 'FastGPTは無料オープンソース版と複数の有料プランを提供し、個人開発者からエンタープライズユーザーまで対応します。料金詳細を確認して最適なプランを選択してください。',
   ar: 'يوفر FastGPT إصدارا مفتوح المصدر مجانيا وخططا مدفوعة متعددة للمطورين الأفراد وفرق المؤسسات. راجع تفاصيل الأسعار واختر الخطة الأنسب لبناء AI Agent.',
@@ -30,9 +33,11 @@ const descMap: Record<string, string> = {
   ms: 'FastGPT menyediakan versi sumber terbuka percuma dan pelbagai pelan berbayar untuk pembangun individu hingga pengguna perusahaan. Lihat butiran harga dan pilih pelan AI Agent yang paling sesuai.'
 };
 
-export async function generateMetadata(
-  { params }: { params: Promise<{ lang?: string }> }
-): Promise<Metadata> {
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ lang?: string }>;
+}): Promise<Metadata> {
   const { lang } = await params;
   const langName = lang || defaultLocale;
   const title = titleMap[langName] || titleMap.en;
@@ -68,7 +73,10 @@ export default async function Index({ params }: { params: Promise<{ lang?: strin
       <main className="pb-[80px] px-[16px] md:px-[32px] relative">
         <GradientBlobs />
 
-        <div className="w-full relative pt-[200px]" style={{ zIndex: 1, maxWidth: 1600, margin: '0 auto' }}>
+        <div
+          className="w-full relative pt-[200px]"
+          style={{ zIndex: 1, maxWidth: 1600, margin: '0 auto' }}
+        >
           <PTitle locale={dict.Pricing} />
 
           <div className="mt-[120px]">

--- a/src/components/home/NotFoundPage.tsx
+++ b/src/components/home/NotFoundPage.tsx
@@ -9,10 +9,11 @@ import ja from '@/locales/ja.json';
 import ms from '@/locales/ms.json';
 import th from '@/locales/th.json';
 import vi from '@/locales/vi.json';
+import zhHant from '@/locales/zh-hant.json';
 import zh from '@/locales/zh.json';
 import { supportedLocaleCodes, type LocaleCode } from '@/lib/locales';
 
-const dictionaries = { en, zh, ja, ar, vi, th, id, ms };
+const dictionaries = { en, 'zh-hant': zhHant, zh, ja, ar, vi, th, id, ms };
 const languages = supportedLocaleCodes;
 const localeVisibilityCss = `
   html${languages
@@ -31,9 +32,10 @@ function getDocsUrl(lang: LocaleCode) {
 }
 
 function getStartUrl(lang: LocaleCode) {
-  return process.env.NEXT_PUBLIC_USER_URL || (lang === 'zh'
-    ? 'https://cloud.fastgpt.cn'
-    : 'https://cloud.fastgpt.io');
+  return (
+    process.env.NEXT_PUBLIC_USER_URL ||
+    (lang === 'zh' ? 'https://cloud.fastgpt.cn' : 'https://cloud.fastgpt.io')
+  );
 }
 
 function NotFoundContent({ lang }: { lang: LocaleCode }) {
@@ -43,7 +45,9 @@ function NotFoundContent({ lang }: { lang: LocaleCode }) {
   const hasFaq = lang === 'en' || lang === 'zh';
 
   return (
-    <div className={`not-found-locale not-found-locale-${lang} mx-auto hidden min-h-[100svh] w-full max-w-[1280px] flex-col px-4 py-6 md:px-8`}>
+    <div
+      className={`not-found-locale not-found-locale-${lang} mx-auto hidden min-h-[100svh] w-full max-w-[1280px] flex-col px-4 py-6 md:px-8`}
+    >
       <header className="flex items-center justify-between">
         <Link href={`/${lang}`} className="flex items-center gap-2" aria-label="FastGPT">
           <FastGPTLogo size={24} />
@@ -74,7 +78,8 @@ function NotFoundContent({ lang }: { lang: LocaleCode }) {
           <div
             className="pointer-events-none absolute left-1/2 top-1/2 h-[420px] w-[min(82vw,720px)] -translate-x-1/2 -translate-y-1/2 rounded-full"
             style={{
-              background: 'radial-gradient(circle, rgba(50,109,255,0.14) 0%, rgba(50,109,255,0.06) 42%, rgba(255,255,255,0) 72%)'
+              background:
+                'radial-gradient(circle, rgba(50,109,255,0.14) 0%, rgba(50,109,255,0.06) 42%, rgba(255,255,255,0) 72%)'
             }}
           />
 

--- a/src/config/price.ts
+++ b/src/config/price.ts
@@ -60,6 +60,67 @@ export const PRICE_PLANS_CLOUD: Record<string, Record<string, any>[]> = {
       features: ['优先深度技术支持', '弹性资源配置', '安全可控', '专属客户经理']
     }
   ],
+  'zh-hant': [
+    {
+      key: 'free',
+      title: '免費版',
+      price: 0,
+      content: '核心功能免費試用',
+      features: [
+        // '100 AI 積分',
+        100,
+        '600 組知識庫索引',
+        '1 個團隊成員',
+        '10 個 Agent',
+        '3 個知識庫',
+        '30 天對話記錄保留',
+        '30 QPM'
+      ]
+    },
+    {
+      key: 'basic',
+      title: '基礎版',
+      price: 99,
+      content: '解鎖 FastGPT 完整功能',
+      features: [
+        4000,
+        '6000 組知識庫索引',
+        '5 個團隊成員',
+        '50 個 Agent',
+        '30 個知識庫',
+        '180 天對話記錄保留',
+        '300 QPM',
+        '站點同步最大 500 頁',
+        '48 小時工單支援回應'
+      ]
+    },
+    {
+      key: 'advanced',
+      title: '進階版',
+      price: 599,
+      content: '適合企業級生產工具',
+      features: [
+        25000,
+        '36000 組知識庫索引',
+        '50 個團隊成員',
+        '200 個 Agent',
+        '100 個知識庫',
+        '360 天對話記錄保留',
+        '720 天團隊操作日誌記錄',
+        '1500 QPM',
+        '站點同步最大 2000 頁',
+        '24 小時工單支援回應',
+        '3 個應用備案'
+      ]
+    },
+    {
+      key: 'custom',
+      title: '客製版',
+      price: '客製計費',
+      content: '協助中大型企業建立核心競爭力',
+      features: ['優先深度技術支援', '彈性資源配置', '安全可控', '專屬客戶經理']
+    }
+  ],
   en: [
     {
       key: 'free',
@@ -309,7 +370,12 @@ export const PRICE_PLANS_CLOUD: Record<string, Record<string, any>[]> = {
       title: 'Gói tùy chỉnh',
       price: 'Tùy chỉnh',
       content: 'Hỗ trợ doanh nghiệp vừa và lớn xây dựng năng lực AI cốt lõi',
-      features: ['Ưu tiên hỗ trợ kỹ thuật chuyên sâu', 'Cấu hình tài nguyên linh hoạt', 'Bảo mật và kiểm soát', 'Quản lý tài khoản riêng']
+      features: [
+        'Ưu tiên hỗ trợ kỹ thuật chuyên sâu',
+        'Cấu hình tài nguyên linh hoạt',
+        'Bảo mật và kiểm soát',
+        'Quản lý tài khoản riêng'
+      ]
     }
   ],
   th: [
@@ -369,7 +435,12 @@ export const PRICE_PLANS_CLOUD: Record<string, Record<string, any>[]> = {
       title: 'แพ็กเกจองค์กร',
       price: 'ราคาตามความต้องการ',
       content: 'สำหรับองค์กรขนาดกลางและใหญ่ที่ต้องการความสามารถเฉพาะทาง',
-      features: ['ซัพพอร์ตเทคนิคเชิงลึกแบบเร่งด่วน', 'จัดสรรทรัพยากรยืดหยุ่น', 'ปลอดภัยและควบคุมได้', 'ผู้จัดการบัญชีเฉพาะ']
+      features: [
+        'ซัพพอร์ตเทคนิคเชิงลึกแบบเร่งด่วน',
+        'จัดสรรทรัพยากรยืดหยุ่น',
+        'ปลอดภัยและควบคุมได้',
+        'ผู้จัดการบัญชีเฉพาะ'
+      ]
     }
   ],
   id: [
@@ -429,7 +500,12 @@ export const PRICE_PLANS_CLOUD: Record<string, Record<string, any>[]> = {
       title: 'Paket Kustom',
       price: 'Kustom',
       content: 'Untuk perusahaan menengah dan besar yang membutuhkan kapabilitas khusus',
-      features: ['Prioritas support teknis mendalam', 'Alokasi resource fleksibel', 'Aman dan terkendali', 'Account manager khusus']
+      features: [
+        'Prioritas support teknis mendalam',
+        'Alokasi resource fleksibel',
+        'Aman dan terkendali',
+        'Account manager khusus'
+      ]
     }
   ],
   ms: [
@@ -489,7 +565,12 @@ export const PRICE_PLANS_CLOUD: Record<string, Record<string, any>[]> = {
       title: 'Pelan Tersuai',
       price: 'Tersuai',
       content: 'Untuk perusahaan sederhana dan besar yang memerlukan keupayaan khusus',
-      features: ['Keutamaan sokongan teknikal mendalam', 'Peruntukan sumber fleksibel', 'Selamat dan terkawal', 'Pengurus akaun khusus']
+      features: [
+        'Keutamaan sokongan teknikal mendalam',
+        'Peruntukan sumber fleksibel',
+        'Selamat dan terkawal',
+        'Pengurus akaun khusus'
+      ]
     }
   ]
 };
@@ -535,6 +616,41 @@ export const PRICE_PLANS_SELF: {
         '支持多种第三方 SSO',
         '原厂技术支持和服务支持',
         '原厂专业应用搭建支持'
+      ]
+    }
+  ],
+  'zh-hant': [
+    {
+      key: 'free',
+      title: '社區版',
+      price: '免費',
+      content: '免費開源，共建 Agent 社群，為 Agent 貢獻力量',
+      features: [
+        '基礎核心功能（Agent、Workflow、知識庫、MCP 等）',
+        '模型管理與模型日誌',
+        '單使用者使用',
+        '社群技術支援服務'
+      ]
+    },
+    {
+      key: 'host',
+      title: '託管版',
+      price: '雲資源計費',
+      content: '基於 Sealos 雲端託管，更安全、更高效部署',
+      features: ['一鍵快速部署', '快速橫向/縱向擴展', '多副本負載均衡', '資料庫自動備份']
+    },
+    {
+      key: 'commercial',
+      title: '商業版',
+      price: '客製化計費',
+      content: '支援更高階功能與私有化部署',
+      features: [
+        '完整商業授權',
+        '企業級可擴展部署方案',
+        '多工作空間與權限管理',
+        '支援多種第三方 SSO',
+        '原廠技術支援和服務支援',
+        '原廠專業應用建置支援'
       ]
     }
   ],
@@ -636,7 +752,12 @@ export const PRICE_PLANS_SELF: {
       title: 'الإصدار المستضاف',
       price: 'حسب موارد السحابة',
       content: 'استضافة على Sealos Cloud لنشر أكثر أمانا وكفاءة',
-      features: ['نشر سريع بنقرة واحدة', 'توسّع أفقي وعمودي سريع', 'موازنة حمل متعددة النسخ', 'نسخ احتياطي تلقائي لقاعدة البيانات']
+      features: [
+        'نشر سريع بنقرة واحدة',
+        'توسّع أفقي وعمودي سريع',
+        'موازنة حمل متعددة النسخ',
+        'نسخ احتياطي تلقائي لقاعدة البيانات'
+      ]
     },
     {
       key: 'commercial',
@@ -671,7 +792,12 @@ export const PRICE_PLANS_SELF: {
       title: 'Bản hosted',
       price: 'Tính theo tài nguyên cloud',
       content: 'Triển khai trên Sealos Cloud để vận hành an toàn và hiệu quả hơn',
-      features: ['Triển khai nhanh một chạm', 'Mở rộng ngang/dọc nhanh', 'Cân bằng tải nhiều replica', 'Tự động sao lưu database']
+      features: [
+        'Triển khai nhanh một chạm',
+        'Mở rộng ngang/dọc nhanh',
+        'Cân bằng tải nhiều replica',
+        'Tự động sao lưu database'
+      ]
     },
     {
       key: 'commercial',
@@ -706,7 +832,12 @@ export const PRICE_PLANS_SELF: {
       title: 'Hosted Edition',
       price: 'คิดค่าบริการตามทรัพยากรคลาวด์',
       content: 'โฮสต์บน Sealos Cloud เพื่อ deploy ได้ปลอดภัยและมีประสิทธิภาพขึ้น',
-      features: ['deploy ได้รวดเร็วในคลิกเดียว', 'ขยายแนวนอนและแนวตั้งได้รวดเร็ว', 'โหลดบาลานซ์หลาย replica', 'สำรองฐานข้อมูลอัตโนมัติ']
+      features: [
+        'deploy ได้รวดเร็วในคลิกเดียว',
+        'ขยายแนวนอนและแนวตั้งได้รวดเร็ว',
+        'โหลดบาลานซ์หลาย replica',
+        'สำรองฐานข้อมูลอัตโนมัติ'
+      ]
     },
     {
       key: 'commercial',
@@ -741,7 +872,12 @@ export const PRICE_PLANS_SELF: {
       title: 'Edisi Hosted',
       price: 'Biaya resource cloud',
       content: 'Di-hosting di Sealos Cloud untuk deployment yang lebih aman dan efisien',
-      features: ['Deployment cepat sekali klik', 'Skalabilitas horizontal dan vertikal cepat', 'Load balancing multi-replica', 'Backup database otomatis']
+      features: [
+        'Deployment cepat sekali klik',
+        'Skalabilitas horizontal dan vertikal cepat',
+        'Load balancing multi-replica',
+        'Backup database otomatis'
+      ]
     },
     {
       key: 'commercial',
@@ -776,7 +912,12 @@ export const PRICE_PLANS_SELF: {
       title: 'Edisi Hosted',
       price: 'Bil sumber cloud',
       content: 'Dihoskan di Sealos Cloud untuk deployment yang lebih selamat dan cekap',
-      features: ['Deployment pantas satu klik', 'Penskalaan mendatar dan menegak pantas', 'Load balancing berbilang replica', 'Backup database automatik']
+      features: [
+        'Deployment pantas satu klik',
+        'Penskalaan mendatar dan menegak pantas',
+        'Load balancing berbilang replica',
+        'Backup database automatik'
+      ]
     },
     {
       key: 'commercial',
@@ -800,6 +941,7 @@ export const PRICE_PLANS_SELF_BUTTON_MAP: {
 } = {
   free: {
     zh: '立即使用',
+    'zh-hant': '立即使用',
     en: 'Get Started',
     ja: '使用開始',
     ar: 'ابدأ الآن',
@@ -811,6 +953,7 @@ export const PRICE_PLANS_SELF_BUTTON_MAP: {
   },
   host: {
     zh: '立即使用',
+    'zh-hant': '立即使用',
     en: 'Get Started',
     ja: '使用開始',
     ar: 'ابدأ الآن',
@@ -822,6 +965,7 @@ export const PRICE_PLANS_SELF_BUTTON_MAP: {
   },
   commercial: {
     zh: '联系销售',
+    'zh-hant': '聯繫銷售',
     en: 'Contact Sales',
     ja: '営業に相談',
     ar: 'تواصل مع المبيعات',

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -136,6 +136,46 @@ export const siteConfigZh: SiteConfig = {
   }
 };
 
+export const siteConfigZhHant: SiteConfig = {
+  ...siteConfig,
+  title: 'FastGPT - 企業級 AI 智能體構建平台 | 開源 RAG 系統',
+  description:
+    'FastGPT 是開源的企業級 AI 智能體構建平台，提供可視化工作流、知識庫和 RAG 系統。50 萬+ 使用者信賴，立即免費開始。',
+  keywords: [
+    'FastGPT',
+    'AI Agent',
+    'AI 智能體',
+    '知識庫',
+    '問答',
+    'workflow',
+    'AI 客服',
+    'RAG 檢索',
+    '可視化 AI 工作流',
+    '企業知識庫',
+    'rag',
+    'ai',
+    'AI 知識庫',
+    'llm',
+    'gpt',
+    'gpt5',
+    'AI 自動化工具'
+  ],
+  openGraph: {
+    ...siteConfig.openGraph,
+    locale: 'zh_Hant',
+    title: 'FastGPT - 企業級 AI 智能體構建平台',
+    description:
+      '靈活的 AI 工作流 + AI 知識庫 + 模板系統 + Agentic RAG = 強大的 AI 智能體構建器。全球 50 萬+ 使用者信賴。',
+    images: [`${baseSiteConfig.url}${OPENGRAPH_IMAGE}`]
+  },
+  twitter: {
+    ...siteConfig.twitter,
+    title: 'FastGPT - 企業級 AI 智能體構建平台',
+    description:
+      'FastGPT 是開源的企業級 AI 智能體構建平台，提供可視化工作流、知識庫和 RAG 系統。50 萬+ 使用者信賴。'
+  }
+};
+
 export const siteConfigJa: SiteConfig = {
   ...siteConfig,
   title: 'FastGPT - エンタープライズ AI エージェント構築プラットフォーム',
@@ -207,7 +247,15 @@ export const siteConfigAr = createLocalizedSiteConfig({
   title: 'FastGPT - منصة بناء وكلاء ذكاء اصطناعي للمؤسسات',
   description:
     'FastGPT منصة مفتوحة المصدر لبناء وكلاء ذكاء اصطناعي للمؤسسات، تجمع بين سير العمل المرئي وقواعد المعرفة وRAG لبناء تطبيقات AI آمنة وقابلة للإنتاج.',
-  keywords: ['FastGPT', 'وكيل ذكاء اصطناعي', 'RAG', 'قاعدة معرفة', 'سير عمل AI', 'LLM', 'أتمتة مؤسسية'],
+  keywords: [
+    'FastGPT',
+    'وكيل ذكاء اصطناعي',
+    'RAG',
+    'قاعدة معرفة',
+    'سير عمل AI',
+    'LLM',
+    'أتمتة مؤسسية'
+  ],
   locale: 'ar_SA',
   ogTitle: 'FastGPT - منصة وكلاء AI للمؤسسات',
   ogDescription: 'ابن وكلاء AI للمؤسسات باستخدام سير عمل مرئي، قواعد معرفة، وAgentic RAG.'
@@ -217,17 +265,34 @@ export const siteConfigVi = createLocalizedSiteConfig({
   title: 'FastGPT - Nền tảng xây dựng AI Agent cho doanh nghiệp',
   description:
     'FastGPT là nền tảng mã nguồn mở để xây dựng AI Agent cho doanh nghiệp, cung cấp workflow trực quan, kho tri thức và RAG để triển khai ứng dụng AI an toàn.',
-  keywords: ['FastGPT', 'AI Agent', 'RAG', 'kho tri thức', 'workflow AI', 'LLM', 'tự động hóa doanh nghiệp'],
+  keywords: [
+    'FastGPT',
+    'AI Agent',
+    'RAG',
+    'kho tri thức',
+    'workflow AI',
+    'LLM',
+    'tự động hóa doanh nghiệp'
+  ],
   locale: 'vi_VN',
   ogTitle: 'FastGPT - Nền tảng AI Agent cho doanh nghiệp',
-  ogDescription: 'Xây dựng AI Agent sẵn sàng sản xuất với workflow trực quan, kho tri thức và Agentic RAG.'
+  ogDescription:
+    'Xây dựng AI Agent sẵn sàng sản xuất với workflow trực quan, kho tri thức và Agentic RAG.'
 });
 
 export const siteConfigTh = createLocalizedSiteConfig({
   title: 'FastGPT - แพลตฟอร์มสร้าง AI Agent สำหรับองค์กร',
   description:
     'FastGPT เป็นแพลตฟอร์มโอเพนซอร์สสำหรับสร้าง AI Agent ระดับองค์กร พร้อมเวิร์กโฟลว์แบบภาพ ฐานความรู้ และ RAG เพื่อสร้างแอป AI ที่ปลอดภัยและใช้งานจริงได้',
-  keywords: ['FastGPT', 'AI Agent', 'RAG', 'ฐานความรู้', 'เวิร์กโฟลว์ AI', 'LLM', 'ระบบอัตโนมัติองค์กร'],
+  keywords: [
+    'FastGPT',
+    'AI Agent',
+    'RAG',
+    'ฐานความรู้',
+    'เวิร์กโฟลว์ AI',
+    'LLM',
+    'ระบบอัตโนมัติองค์กร'
+  ],
   locale: 'th_TH',
   ogTitle: 'FastGPT - แพลตฟอร์ม AI Agent สำหรับองค์กร',
   ogDescription: 'สร้าง AI Agent สำหรับงานจริงด้วยเวิร์กโฟลว์แบบภาพ ฐานความรู้ และ Agentic RAG.'
@@ -237,18 +302,36 @@ export const siteConfigId = createLocalizedSiteConfig({
   title: 'FastGPT - Platform pembuat AI Agent untuk perusahaan',
   description:
     'FastGPT adalah platform open-source untuk membangun AI Agent perusahaan, dengan workflow visual, knowledge base, dan RAG untuk aplikasi AI yang aman dan siap produksi.',
-  keywords: ['FastGPT', 'AI Agent', 'RAG', 'knowledge base', 'workflow AI', 'LLM', 'otomatisasi perusahaan'],
+  keywords: [
+    'FastGPT',
+    'AI Agent',
+    'RAG',
+    'knowledge base',
+    'workflow AI',
+    'LLM',
+    'otomatisasi perusahaan'
+  ],
   locale: 'id_ID',
   ogTitle: 'FastGPT - Platform AI Agent untuk perusahaan',
-  ogDescription: 'Bangun AI Agent siap produksi dengan workflow visual, knowledge base, dan Agentic RAG.'
+  ogDescription:
+    'Bangun AI Agent siap produksi dengan workflow visual, knowledge base, dan Agentic RAG.'
 });
 
 export const siteConfigMs = createLocalizedSiteConfig({
   title: 'FastGPT - Platform membina AI Agent untuk perusahaan',
   description:
     'FastGPT ialah platform sumber terbuka untuk membina AI Agent perusahaan, dengan aliran kerja visual, pangkalan pengetahuan dan RAG untuk aplikasi AI yang selamat dan sedia produksi.',
-  keywords: ['FastGPT', 'AI Agent', 'RAG', 'pangkalan pengetahuan', 'aliran kerja AI', 'LLM', 'automasi perusahaan'],
+  keywords: [
+    'FastGPT',
+    'AI Agent',
+    'RAG',
+    'pangkalan pengetahuan',
+    'aliran kerja AI',
+    'LLM',
+    'automasi perusahaan'
+  ],
   locale: 'ms_MY',
   ogTitle: 'FastGPT - Platform AI Agent untuk perusahaan',
-  ogDescription: 'Bina AI Agent sedia produksi dengan aliran kerja visual, pangkalan pengetahuan dan Agentic RAG.'
+  ogDescription:
+    'Bina AI Agent sedia produksi dengan aliran kerja visual, pangkalan pengetahuan dan Agentic RAG.'
 });

--- a/src/lib/htmlLang.ts
+++ b/src/lib/htmlLang.ts
@@ -22,7 +22,15 @@ export const htmlLangScript = `
   var defaultLocale = '${normalizedBuildDefaultLocale}';
   function normalize(locale) {
     if (!locale) return '';
-    locale = String(locale).toLowerCase();
+    locale = String(locale).toLowerCase().replace(/_/g, '-');
+    if (
+      locale.indexOf('zh-hant') === 0 ||
+      locale.indexOf('zh-tw') === 0 ||
+      locale.indexOf('zh-hk') === 0 ||
+      locale.indexOf('zh-mo') === 0
+    ) {
+      return 'zh-hant';
+    }
     for (var i = 0; i < locales.length; i++) {
       if (locale.indexOf(locales[i]) === 0) return locales[i];
     }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -6,6 +6,7 @@ import {
   siteConfigMs,
   siteConfigTh,
   siteConfigVi,
+  siteConfigZhHant,
   siteConfigZh
 } from '@/config/site';
 import { localeNames, normalizeLocale, supportedLocaleCodes } from '@/lib/locales';
@@ -20,6 +21,8 @@ export const defaultLocale = normalizeLocale(process.env.NEXT_PUBLIC_DEFAULT_LOC
 export function getConfigForLocale(locale: string) {
   const normalized = normalizeLocale(locale);
   switch (normalized) {
+    case 'zh-hant':
+      return siteConfigZhHant;
     case 'zh':
       return siteConfigZh;
     case 'ja':
@@ -41,6 +44,7 @@ export function getConfigForLocale(locale: string) {
 
 const dictionaries: any = {
   en: () => import('@/locales/en.json').then((module) => module.default),
+  'zh-hant': () => import('@/locales/zh-hant.json').then((module) => module.default),
   zh: () => import('@/locales/zh.json').then((module) => module.default),
   ja: () => import('@/locales/ja.json').then((module) => module.default),
   ar: () => import('@/locales/ar.json').then((module) => module.default),

--- a/src/lib/locales.ts
+++ b/src/lib/locales.ts
@@ -1,12 +1,34 @@
 export const localeConfigs = [
   { code: 'en', name: 'English', flag: '🇺🇸', dir: 'ltr', ogLocale: 'en_US', htmlLang: 'en-US' },
-  { code: 'zh', name: '中文', flag: '🇨🇳', dir: 'ltr', ogLocale: 'zh_CN', htmlLang: 'zh-CN' },
+  { code: 'zh', name: '简体中文', flag: '🇨🇳', dir: 'ltr', ogLocale: 'zh_CN', htmlLang: 'zh-CN' },
+  {
+    code: 'zh-hant',
+    name: '繁體中文',
+    flag: '🇨🇳',
+    dir: 'ltr',
+    ogLocale: 'zh_Hant',
+    htmlLang: 'zh-Hant'
+  },
   { code: 'ja', name: '日本語', flag: '🇯🇵', dir: 'ltr', ogLocale: 'ja_JP', htmlLang: 'ja-JP' },
   { code: 'ar', name: 'العربية', flag: '🇸🇦', dir: 'rtl', ogLocale: 'ar_SA', htmlLang: 'ar-SA' },
   { code: 'vi', name: 'Tiếng Việt', flag: '🇻🇳', dir: 'ltr', ogLocale: 'vi_VN', htmlLang: 'vi-VN' },
   { code: 'th', name: 'ไทย', flag: '🇹🇭', dir: 'ltr', ogLocale: 'th_TH', htmlLang: 'th-TH' },
-  { code: 'id', name: 'Bahasa Indonesia', flag: '🇮🇩', dir: 'ltr', ogLocale: 'id_ID', htmlLang: 'id-ID' },
-  { code: 'ms', name: 'Bahasa Melayu', flag: '🇲🇾', dir: 'ltr', ogLocale: 'ms_MY', htmlLang: 'ms-MY' }
+  {
+    code: 'id',
+    name: 'Bahasa Indonesia',
+    flag: '🇮🇩',
+    dir: 'ltr',
+    ogLocale: 'id_ID',
+    htmlLang: 'id-ID'
+  },
+  {
+    code: 'ms',
+    name: 'Bahasa Melayu',
+    flag: '🇲🇾',
+    dir: 'ltr',
+    ogLocale: 'ms_MY',
+    htmlLang: 'ms-MY'
+  }
 ] as const;
 
 export type LocaleCode = (typeof localeConfigs)[number]['code'];
@@ -14,34 +36,33 @@ export type LocaleDirection = (typeof localeConfigs)[number]['dir'];
 
 export const supportedLocaleCodes = localeConfigs.map((locale) => locale.code);
 
-export const localeNames = localeConfigs.reduce(
-  (acc, locale) => {
-    acc[locale.code] = locale.name;
-    return acc;
-  },
-  {} as Record<LocaleCode, string>
-);
+export const localeNames = localeConfigs.reduce((acc, locale) => {
+  acc[locale.code] = locale.name;
+  return acc;
+}, {} as Record<LocaleCode, string>);
 
-export const localeMap = localeConfigs.reduce(
-  (acc, locale) => {
-    acc[locale.code] = locale.ogLocale;
-    return acc;
-  },
-  {} as Record<string, string>
-);
+export const localeMap = localeConfigs.reduce((acc, locale) => {
+  acc[locale.code] = locale.ogLocale;
+  return acc;
+}, {} as Record<string, string>);
 
-export const localeDirections = localeConfigs.reduce(
-  (acc, locale) => {
-    acc[locale.code] = locale.dir;
-    return acc;
-  },
-  {} as Record<LocaleCode, LocaleDirection>
-);
+export const localeDirections = localeConfigs.reduce((acc, locale) => {
+  acc[locale.code] = locale.dir;
+  return acc;
+}, {} as Record<LocaleCode, LocaleDirection>);
 
 export function normalizeLocale(locale: string | undefined | null): LocaleCode {
   if (!locale) return 'en';
 
-  const normalized = locale.toLowerCase();
+  const normalized = locale.toLowerCase().replace(/_/g, '-');
+  if (
+    normalized.startsWith('zh-hant') ||
+    normalized.startsWith('zh-tw') ||
+    normalized.startsWith('zh-hk') ||
+    normalized.startsWith('zh-mo')
+  ) {
+    return 'zh-hant';
+  }
   if (normalized.startsWith('zh')) return 'zh';
   if (normalized.startsWith('en')) return 'en';
   if (normalized.startsWith('ja')) return 'ja';

--- a/src/locales/zh-hant.json
+++ b/src/locales/zh-hant.json
@@ -1,0 +1,528 @@
+{
+  "links": [
+    {
+      "label": "定價",
+      "href": "/price"
+    },
+    {
+      "label": "文檔",
+      "href": "https://doc.fastgpt.io/docs/introduction"
+    },
+    {
+      "label": "學習中心",
+      "href": "https://video.fastgpt.cn/videos"
+    }
+  ],
+  "Pricing": {
+    "badge": "定價",
+    "popular": "最受歡迎",
+    "cloud": "雲服務",
+    "self": "私有部署",
+    "annual": "按年",
+    "pay10": "支付10個月，暢享一年！",
+    "upgrade": "升級套餐",
+    "contact": "聯繫商務",
+    "allFeatures": "包含社區版所有功能",
+    "moreFeatures": "更多企業級功能請",
+    "moreFeaturesLink": "查看文檔",
+    "chooseVersion": "選擇更適合你的版本",
+    "freeUse": "免費使用或升級更高的套餐",
+    "monthly": "按月",
+    "monthUnit": "月",
+    "yearUnit": "年",
+    "monthPriceFormat": "¥{{price}}/月",
+    "yearPriceFormat": "¥{{price}}/年",
+    "aiCredits": "AI 積分",
+    "faq": {
+      "badge": "FAQ",
+      "title": "常見問題",
+      "subtitle": "關於套餐、AI 積分和資源限制的常見問題",
+      "items": [
+        {
+          "title": "是否切換訂閱套餐？",
+          "desc": "套餐使用規則為優先使用更高級的套餐，因此，購買的新套餐若比當前套餐更高級，則新套餐立即生效：否則將繼續使用當前套餐。"
+        },
+        {
+          "title": "在哪裡查看已訂閱的套餐？",
+          "desc": "賬號-個人信息-套餐詳情-使用情況。您可以查看所擁有套餐的生效和到期時間。當付費套餐到期後將自動切換免費版。"
+        },
+        {
+          "title": "什麼是AI積分？",
+          "desc": "每次調用AI模型時，都會消耗一定的AI積分。具體的計算標準可參考上方的“AI 積分計算標準”。系統會優先採用模型廠商返回的實際 usage，若為空，則採用GPT3.5的計算方式進行估算，1Token≈0.7中文字符≈0.9英文單詞，連續出現的字符可能被認為是1個Tokens。"
+        },
+        {
+          "title": "AI積分會過期麼？",
+          "desc": "會過期。當前套餐過期後，AI積分將會清空，並更新為新套餐的AI積分。年度套餐的AI積分時長為1年，而不是每個月。"
+        },
+        {
+          "title": "知識庫存儲怎麼計算？",
+          "desc": "1條知識庫存儲等於1條知識庫索引。一條分塊數據，通常對應多條索引，可以在單個知識庫集合中看到\"n組索引\""
+        },
+        {
+          "title": "知識庫索引什麼時候會減少？",
+          "desc": "當你刪除知識庫內容時，知識庫索引數量會在 5 分鐘內減少。"
+        },
+        {
+          "title": "額外資源包可以疊加麼？",
+          "desc": "可以的。每次購買的資源包都是獨立的，在其有效期內將會疊加使用。AI積分會優先扣除最先過期的資源包。"
+        },
+        {
+          "title": "QPM 是什麼？",
+          "desc": "主要指團隊每分鐘請求 Agent 的最大次數，與單個 Agent 複雜度無關。其他 OpenAPI 接口也受此影響，每個接口單獨計算。"
+        },
+        {
+          "title": "一個月,一年具體是多長時間？",
+          "desc": "一個月按 30 天計算，一年按 360 天計算。"
+        },
+        {
+          "title": "免費版數據會清除麼？",
+          "desc": "免費版團隊（免費版且未購買額外套餐）連續 30 天未登錄系統，系統會自動清除該團隊下所有知識庫內容。"
+        }
+      ]
+    }
+  },
+  "FAQ": {
+    "badge": "FAQ",
+    "title": "常見問題解答",
+    "subtitle": "查找關於 FastGPT 的常見問題解答",
+    "description": "關於 FastGPT 的常見問題解答",
+    "viewMore": "查看更多",
+    "allCategories": "全部分類",
+    "readMore": "閱讀更多",
+    "readDetail": "查看詳情",
+    "backToList": "返回",
+    "relatedQuestions": "相關問題",
+    "searchPlaceholder": "搜索問題...",
+    "noResults": "未找到匹配的問題",
+    "clearFilters": "清除篩選",
+    "filterByCategory": "按分類篩選",
+    "showing": "顯示",
+    "question": "個問題",
+    "questions": "個問題",
+    "previous": "上一個",
+    "next": "下一個"
+  },
+  "CTA": {
+    "title": "現在開始構建專屬你的 AI Agent。",
+    "description1": "FastGPT, 讓 AI Agent 構建更輕鬆!",
+    "description2": "",
+    "description3": "",
+    "description4": "",
+    "description5": "",
+    "description6": ""
+  },
+  "CTAButton": {
+    "askTitle": "商務諮詢",
+    "title": "免費使用"
+  },
+  "Home": {
+    "navCta": {
+      "trial": "立即開始",
+      "consult": "商務諮詢"
+    },
+    "hero": {
+      "githubStars": "Github Stars",
+      "followUs": "關注我們",
+      "brand": "FastGPT",
+      "title": "企業級AI生產力引擎",
+      "subtitle": "構建安全、可控的企業級 AI Agent",
+      "trial": "立即開始",
+      "consult": "商務諮詢"
+    },
+    "trustedBy": {
+      "caption": "深受行業領軍團隊信賴"
+    },
+    "stats": {
+      "items": [
+        {
+          "label": "GitHub Stars",
+          "desc": "全球開發者技術背書"
+        },
+        {
+          "label": "平臺用戶",
+          "desc": "賦能各行業業務團隊"
+        },
+        {
+          "label": "私有化部署案例",
+          "desc": "核心業務場景成熟落地"
+        }
+      ]
+    },
+    "productHighlights": {
+      "badge": "產品亮點",
+      "title": "生產級 AI 智能體",
+      "subtitle": "一站式解決企業 AI 落地難題",
+      "items": [
+        {
+          "key": "blocks",
+          "title": "像搭積木一樣，構建業務的 AI 智能體",
+          "desc": "可視化工作流、強擴展生態 API 無縫對接"
+        },
+        {
+          "key": "kb",
+          "title": "拒絕幻覺，打造精準企業知識庫",
+          "desc": "混合檢索拒絕幻覺，自動清洗數據，實時更新維護"
+        },
+        {
+          "key": "lifecycle",
+          "title": "看得見、管得住，大模型全生命週期管理",
+          "desc": "兼容全模型接入，提供調試審計，確保合規可控"
+        },
+        {
+          "key": "production",
+          "title": "生產級，生產環境構建的專業架構",
+          "desc": "支持 SSO 與 RBAC 權限，打造千人千面安全門戶"
+        },
+        {
+          "key": "partner",
+          "title": "不僅僅是工具，更是 AI 落地的全程夥伴",
+          "desc": "豐富企業實戰經驗，從調研到定製 POC，全程陪跑交付"
+        }
+      ]
+    },
+    "solutions": {
+      "badge": "行業解決方案",
+      "title": "覆蓋核心業務場景",
+      "subtitle": "針對不同職能與行業，提供開箱即用的 AI 解決方案",
+      "consult": "商務諮詢",
+      "tabs": [
+        {
+          "key": "sales",
+          "label": "銷售 & 市場",
+          "items": [
+            {
+              "key": "assistant",
+              "title": "智能銷售助手",
+              "desc": "嵌入平臺，AI 實時輔助查資料、寫話術，讓回覆快且專業。"
+            },
+            {
+              "key": "report",
+              "title": "金融行情播報",
+              "desc": "自動抓取行情數據，按模板生成圖表與日報，告別繁瑣人工製表。"
+            },
+            {
+              "key": "training",
+              "title": "銷售培訓與陪練",
+              "desc": "AI 模擬真實客戶對練，自動評分糾錯，幫助新人快速掌握銷售話術。"
+            }
+          ]
+        },
+        {
+          "key": "service",
+          "label": "客服 & 運營",
+          "items": [
+            {
+              "key": "ticket",
+              "title": "智能工單派單",
+              "desc": "懂文字更能懂圖片，自動識別訴求並精準派單，大幅提升服務效率。"
+            },
+            {
+              "key": "copy",
+              "title": "營銷文案生成",
+              "desc": "懂賣點更懂平臺風格，自動規避違禁詞，批量產出高質量營銷文案。"
+            },
+            {
+              "key": "insight",
+              "title": "客戶體驗洞察",
+              "desc": "自動分析客戶情緒與槽點，生成改進建議，助力產品精準優化迭代。"
+            }
+          ]
+        },
+        {
+          "key": "hr",
+          "label": "行政 & 人事",
+          "items": [
+            {
+              "key": "resume",
+              "title": "智能簡歷篩選",
+              "desc": "AI 自動閱讀海量簡歷，精準匹配打分並推薦，幫 HR 快速鎖定人才。"
+            },
+            {
+              "key": "policy",
+              "title": "員工制度問答",
+              "desc": "導入制度手冊，員工有疑問直接對話 AI，無需翻閱，即問即答。"
+            },
+            {
+              "key": "meeting",
+              "title": "會議紀要助手",
+              "desc": "錄音實時轉文字，AI 自動提煉核心觀點與決議，一鍵生成結構化紀要。"
+            }
+          ]
+        },
+        {
+          "key": "finance",
+          "label": "財務 & 法務",
+          "items": [
+            {
+              "key": "expense",
+              "title": "費用報銷審核",
+              "desc": "拍照上傳，AI 自動核對預算與規則，智能攔截異常，解放財務雙手。"
+            },
+            {
+              "key": "contract",
+              "title": "合同智能審查",
+              "desc": "秒級比對法規標準，高亮風險條款並給出修改建議，嚴防合同漏洞。"
+            },
+            {
+              "key": "dd",
+              "title": "盡調報告生成",
+              "desc": "自動收集工商經營數據，直接生成結構化報告，告別繁瑣人工蒐集。"
+            }
+          ]
+        }
+      ]
+    },
+    "cases": {
+      "badge": "客戶成功案例",
+      "title": "行業標杆案例",
+      "subtitle": "幫助 1000+ 企業實現真實業務場景的降本增效",
+      "learnMore": "瞭解更多",
+      "items": [
+        {
+          "key": "cetc",
+          "title": "縮短新員工適應期，構建研發知識助手",
+          "metrics": [
+            {
+              "value": "1 周+",
+              "label": "培訓週期縮短"
+            },
+            {
+              "value": "10%",
+              "label": "重複諮詢降低"
+            },
+            {
+              "value": "30s",
+              "label": "檢索耗時"
+            }
+          ]
+        },
+        {
+          "key": "cms",
+          "title": "重塑投研生產力，基金研報自動化生成",
+          "metrics": [
+            {
+              "value": "90%+",
+              "label": "自動化率超過"
+            },
+            {
+              "value": "<1%",
+              "label": "數據差錯"
+            },
+            {
+              "value": "90%",
+              "label": "製作耗時縮短"
+            }
+          ]
+        },
+        {
+          "key": "snow",
+          "title": "深度集成 OA 系統，費用報銷職能審核",
+          "metrics": [
+            {
+              "value": "50%",
+              "label": "審核提效"
+            },
+            {
+              "value": "70%",
+              "label": "異常檢出提升"
+            },
+            {
+              "value": "60%",
+              "label": "終審錯誤降低"
+            }
+          ]
+        },
+        {
+          "key": "zhaozhao",
+          "title": "日均諮詢破萬，AI 客服 7*24h 秒回",
+          "metrics": [
+            {
+              "value": "1 s",
+              "label": "響應速度秒級"
+            },
+            {
+              "value": "42%",
+              "label": "轉人工率降低"
+            },
+            {
+              "value": "標準化",
+              "label": "服務質量"
+            }
+          ]
+        },
+        {
+          "key": "lcfc",
+          "title": "告別萬行 Excel 卡頓，自然語言即問即查",
+          "metrics": [
+            {
+              "value": "240+ 分鐘",
+              "label": "數據提效"
+            },
+            {
+              "value": "90%",
+              "label": "系統卡頓降低"
+            },
+            {
+              "value": "3%",
+              "label": "錯誤率降低至"
+            }
+          ]
+        }
+      ]
+    },
+    "brandWall": {
+      "badge": "品牌牆",
+      "title": "合作客戶",
+      "subtitle": "1000+ 企業的優選 AI 合作客戶"
+    },
+    "services": {
+      "badge": "服務與認證",
+      "title": "專業交付，價值保障",
+      "subtitle": "從諮詢到交付，我們是技術服務提供者，更是您 AI 落地的長期夥伴與堅實後盾。",
+      "items": [
+        {
+          "key": "community",
+          "title": "開源生態支持",
+          "desc": "社區模板文檔齊備，助力快速上手"
+        },
+        {
+          "key": "consult",
+          "title": "專家諮詢支持",
+          "desc": "1v1 診斷痛點，架構諮詢 POC 驗證"
+        },
+        {
+          "key": "deploy",
+          "title": "搭建落地輔助",
+          "desc": "成熟方案全程陪跑，系統培訓落地"
+        },
+        {
+          "key": "custom",
+          "title": "企業定製開發",
+          "desc": "深度集成業務系統，長期運維保障"
+        }
+      ]
+    },
+    "faq": {
+      "badge": "喜歡這個開源 AI Agent 構建平臺嗎？",
+      "badgeLink": "點個 Star 吧 🌟",
+      "badgeLinkUrl": "https://github.com/labring/FastGPT",
+      "title": "常見問題",
+      "subtitle": "關於 FastGPT 的常見問題解答",
+      "items": [
+        {
+          "title": "開源版可以商業化嗎？",
+          "content": "FastGPT 允許被用於商業化，例如作為其他應用的「後端即服務」使用，或者作為應用開發平臺提供給企業。然而，當涉及到多租戶 SaaS 服務或者 LOGO 及版權信息時，必須聯繫作者獲得商業許可。"
+        },
+        {
+          "title": "FastGPT 知識庫可以導入哪些格式的文檔？",
+          "content": "FastGPT 支持導入 Word、PDF、Excel、Markdown 以及網頁鏈接等格式文檔，同時還支持同步整個 Web 站點的數據，自動完成文本預處理、向量化和 QA 分割，節省手動訓練時間，提高效率。"
+        },
+        {
+          "title": "FastGPT 可以接入哪些模型？",
+          "content": "只要您接入的模型接口 API 與 OpenAI 官方接口對齊，都可以接入 FastGPT。您可以使用 One API 這樣的項目來統一接入不同的模型，並對外提供與 OpenAI 官方接口對齊的 API。"
+        },
+        {
+          "title": "如果我在使用 FastGPT 時遇到問題該怎麼辦？",
+          "content": "如果你在使用 FastGPT 時遇到任何問題，請加入社群或者論壇發帖與我們聯繫。"
+        }
+      ]
+    },
+    "cta": {
+      "brand": "FastGPT",
+      "title": "讓AI成為業務增長的新引擎",
+      "subtitle": "即刻嘗試",
+      "trial": "立即開始",
+      "consult": "商務諮詢"
+    },
+    "footer": {
+      "tagline": "企業級AI生產力引擎",
+      "columns": {
+        "service": {
+          "title": "服務",
+          "items": {
+            "cloud": "雲服務",
+            "private": "私有化",
+            "community": "社區版",
+            "docs": "文檔中心"
+          }
+        },
+        "partner": {
+          "title": "生態夥伴"
+        },
+        "more": {
+          "title": "更多信息",
+          "email": "郵箱：Dennis@sealos.io",
+          "lanqiao": "藍橋雲課 x FastGPT教程",
+          "book": "FastGPT官方教材（紙質書）"
+        }
+      },
+      "qr": {
+        "wechat": "官方公眾號（微信）",
+        "feishu": "官方社群（飛書）",
+        "group": "官方社群（微信）"
+      },
+      "copyright": "Copyright"
+    }
+  },
+  "Enterprise": {
+    "Hero": {
+      "maker": "企業正在使用 FastGPT 企業一體機定製服務",
+      "title": "FastGPT 企業一體機",
+      "description": "軟硬一體機交付，開箱即用的大模型與 FastGPT 企業一體機，搭配 Agent 企業級服務，數十個成熟通用智能體與各行各業垂類智能體應用，快速助力企業大模型應用落地。"
+    },
+    "Models": {
+      "title": "產品系列",
+      "description": "為不同規模和需求的企業量身打造，提供推理、推訓兩種選擇。"
+    },
+    "Advantages": {
+      "title": "選擇 FastGPT 企業一體機",
+      "description": "我們不止提供硬件，更提供穩定、高效、開放的企業級 AI 底座。"
+    },
+    "Benchmark": {
+      "title": "企業級模型基準測試指標（短文本測試）",
+      "model": "模型",
+      "hardware": "配置",
+      "concurrent40": "40併發（吞吐量/TTFT）",
+      "concurrent160": "160併發（吞吐量/TTFT）",
+      "concurrent256": "256併發（吞吐量/TTFT）"
+    },
+    "Partners": {
+      "title": "服務值得信賴的客戶",
+      "description": "覆蓋金融、製造、電商、教育等10+行業，幫助上百家企業完成 AI 落地的最後一公里。"
+    },
+    "CTA": {
+      "title": "準備好部署你的 FastGPT 企業一體機了嗎？",
+      "description": "立即聯繫我們的專家，瞭解 FastGPT 企業一體機如何為你的業務帶來變革，並申請產品演示。",
+      "link": "申請產品演示"
+    }
+  },
+  "NotFound": {
+    "eyebrow": "404",
+    "title": "頁面沒有找到",
+    "desc": "這個地址可能已經移動、刪除，或者暫時不可訪問。你可以回到首頁，或去 FAQ 查找相關問題。",
+    "home": "返回首頁",
+    "faq": "查看 FAQ",
+    "docs": "文檔中心",
+    "start": "立即開始"
+  },
+  "JsonLd": {
+    "siteName": "FastGPT",
+    "pageTitle": "FastGPT - 企業級 AI 智能體構建平臺 | 開源 RAG 系統",
+    "description": "FastGPT 是開源的企業級 AI 智能體構建平臺，提供可視化工作流、知識庫和 RAG 系統。50萬+用戶信賴，立即免費開始。",
+    "inLanguage": "zh-Hant",
+    "organizationName": "FastGPT",
+    "applicationCategory": "BusinessApplication",
+    "operatingSystem": "Web",
+    "offerDescription": "提供免費開源版本",
+    "authorName": "labring",
+    "breadcrumbHome": "FastGPT",
+    "featureList": [
+      "可視化 AI 工作流編排",
+      "企業知識庫與 Agentic RAG",
+      "AI 應用模板系統",
+      "多模型接入與 OpenAI API 兼容",
+      "企業私有化部署與權限管理",
+      "免代碼 AI Agent 構建"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add the zh-hant locale registry, dictionary, SEO config, and NotFound support
- add Traditional Chinese pricing copy and price page metadata
- generate zh-hant llms.txt and include zh-hant in static export helper scripts
- normalize zh-Hant/zh-TW/zh-HK/zh-MO browser or env values to the zh-hant route

## Validation
- npm run clean-locales
- npx tsc --noEmit --pretty false --tsBuildInfoFile /tmp/fastgpt-home-tsconfig-zh-hant.tsbuildinfo
- npm run lint
- git diff --check
- npm run build