### PR TITLE
fix: sync homepage GitHub star display

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -58,10 +58,22 @@ jobs:
             const prNumber = parseInt('${{ steps.pr.outputs.number }}');
             const deployUrl = '${{ steps.deploy.outputs.deployment-url }}';
             const marker = '<!-- fastgpt-home-preview -->';
+            const deployedAt = new Date().toLocaleString('zh-CN', {
+              timeZone: 'Asia/Shanghai',
+              hour12: false,
+              year: 'numeric',
+              month: '2-digit',
+              day: '2-digit',
+              hour: '2-digit',
+              minute: '2-digit',
+              second: '2-digit',
+            });
             const body = `${marker}
             🚀 **FastGPT Homepage Preview Ready!**
 
             📱 **Preview URL:** ${deployUrl}
+
+            🕒 **Updated At:** ${deployedAt} (UTC+8)
 
             🔗 [👀 Click here to visit preview](${deployUrl})
 

--- a/src/components/home/CTA.tsx
+++ b/src/components/home/CTA.tsx
@@ -89,7 +89,7 @@ export default function CTA({ t }: { t: CTAT }) {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, margin: '-80px' }}
                 transition={{ duration: 0.6, delay: 0.3 }}
-                className="flex flex-row items-stretch md:items-center gap-[32px] md:gap-8 w-full"
+                className="flex flex-col md:flex-row items-stretch md:items-center gap-3 md:gap-8 w-full"
               >
                 <motion.a
                   href={startUrl}
@@ -97,7 +97,7 @@ export default function CTA({ t }: { t: CTAT }) {
                   whileHover={{ scale: 1.04 }}
                   whileTap={{ scale: 0.97 }}
                   aria-label={t.trial}
-                  className="flex-1 md:flex-initial inline-flex items-center justify-center h-[44px] md:h-11 px-6 md:px-8 rounded-[99px] text-[14px] md:text-[16px] font-semibold leading-[1.5em] bg-btn-light-bg border border-btn-light-border text-[#3d3d3d] transition-colors hover:bg-white/80"
+                  className="w-full md:w-auto md:flex-initial inline-flex items-center justify-center h-[44px] md:h-11 px-6 md:px-8 rounded-[99px] text-[14px] md:text-[16px] font-semibold leading-[1.5em] bg-btn-light-bg border border-btn-light-border text-[#3d3d3d] transition-colors hover:bg-white/80"
                 >
                   {t.trial}
                 </motion.a>
@@ -108,7 +108,7 @@ export default function CTA({ t }: { t: CTAT }) {
                   whileHover={{ scale: 1.04 }}
                   whileTap={{ scale: 0.97 }}
                   aria-label={t.consult}
-                  className="flex-1 md:flex-initial inline-flex items-center justify-center h-[44px] md:h-11 px-6 md:px-8 rounded-[99px] text-[14px] md:text-[16px] font-medium leading-[20px] tracking-[-0.12px] bg-btn-dark border border-btn-border text-white transition-opacity hover:opacity-90"
+                  className="w-full md:w-auto md:flex-initial inline-flex items-center justify-center h-[44px] md:h-11 px-6 md:px-8 rounded-[99px] text-[14px] md:text-[16px] font-medium leading-[20px] tracking-[-0.12px] bg-btn-dark border border-btn-border text-white transition-opacity hover:opacity-90"
                 >
                   {t.consult}
                 </motion.a>

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -6,7 +6,7 @@ import { useEffect, useRef, useState, ReactNode } from 'react';
 import Image from 'next/image';
 import { assets } from '@/components/home/assets';
 import { useStartUrl, CONSULT_URL } from '@/components/home/hooks/useStartUrl';
-import { getCachedGitHubStars } from '@/lib/githubStarsClient';
+import { formatGitHubStars } from '@/lib/githubStarsDisplay';
 
 interface HeroProps {
   stars: number;
@@ -63,20 +63,8 @@ export default function Hero({ stars: initialStars, t, children }: HeroProps) {
   const scale = useTransform(smoothProgress, [0, 0.20], [0.95, 1]);
   const offsetY = useTransform(smoothProgress, [0, 0.20], isDesktop ? [-160, 0] : [-80, 0]);
 
-
-  const [stars, setStars] = useState(initialStars);
-  useEffect(() => {
-    const run = async () => {
-      const nextStars = await getCachedGitHubStars(initialStars);
-      if (nextStars !== initialStars) {
-        setStars(nextStars);
-      }
-    };
-    run();
-  }, [initialStars]);
-
   const startUrl = useStartUrl();
-  const formattedStars = stars ? `${stars.toLocaleString()}+` : '25,999+';
+  const formattedStars = formatGitHubStars(initialStars);
 
   return (
     <section

--- a/src/components/home/HomeHeroSection.tsx
+++ b/src/components/home/HomeHeroSection.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Hero from '@/components/home/Hero';
+import TrustedBy from '@/components/home/TrustedBy';
+import Stats from '@/components/home/Stats';
+import { getCachedGitHubStars } from '@/lib/githubStarsClient';
+
+export default function HomeHeroSection({
+  stars: initialStars,
+  t
+}: {
+  stars: number;
+  t: {
+    hero: Parameters<typeof Hero>[0]['t'];
+    trustedBy: Parameters<typeof TrustedBy>[0]['t'];
+    stats: Parameters<typeof Stats>[0]['t'];
+  };
+}) {
+  const [stars, setStars] = useState(initialStars);
+
+  useEffect(() => {
+    const run = async () => {
+      const nextStars = await getCachedGitHubStars(initialStars);
+      if (nextStars !== initialStars) {
+        setStars(nextStars);
+      }
+    };
+    run();
+  }, [initialStars]);
+
+  return (
+    <Hero stars={stars} t={t.hero}>
+      <TrustedBy t={t.trustedBy} />
+      <Stats stars={stars} t={t.stats} />
+    </Hero>
+  );
+}

--- a/src/components/home/HomeLanding.tsx
+++ b/src/components/home/HomeLanding.tsx
@@ -1,8 +1,6 @@
 import HomeThemeFix from '@/components/home/HomeThemeFix';
 import Navbar from '@/components/home/Navbar';
-import Hero from '@/components/home/Hero';
-import TrustedBy from '@/components/home/TrustedBy';
-import Stats from '@/components/home/Stats';
+import HomeHeroSection from '@/components/home/HomeHeroSection';
 import ProductHighlights from '@/components/home/ProductHighlights';
 import Solutions from '@/components/home/Solutions';
 import CaseStudies from '@/components/home/CaseStudies';
@@ -28,10 +26,7 @@ export default function HomeLanding({
       <HomeThemeFix />
       <Navbar links={dict.links} t={t.navCta} />
       <main className="m-0 p-0">
-        <Hero stars={stars} t={t.hero}>
-          <TrustedBy t={t.trustedBy} />
-          <Stats stars={stars} t={t.stats} />
-        </Hero>
+        <HomeHeroSection stars={stars} t={t} />
         <ProductHighlights t={t.productHighlights} />
         <Solutions t={t.solutions} />
         <CaseStudies t={t.cases} />

--- a/src/components/home/Stats.tsx
+++ b/src/components/home/Stats.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
+import { formatGitHubStarsInThousands } from '@/lib/githubStarsDisplay';
 
 function useCountUp(end: number, decimals = 0, duration = 2000) {
   const [value, setValue] = useState(0);
@@ -41,7 +42,7 @@ interface StatsProps {
 }
 
 export default function Stats({ stars, t }: StatsProps) {
-  const githubStarsK = stars ? parseFloat((stars / 1000).toFixed(2)) : 26;
+  const githubStarsK = formatGitHubStarsInThousands(stars);
 
   const stats = [
     { end: githubStarsK, decimals: 2, suffix: 'k', ...t.items[0] },
@@ -54,7 +55,7 @@ export default function Stats({ stars, t }: StatsProps) {
       <div className="max-w-[min(92vw,1300px)] md:max-w-[min(85vw,1300px)] mx-auto">
         <div className="flex flex-col gap-[32px] items-center md:flex-row md:gap-0 md:items-start md:justify-between">
           {stats.map((stat, i) => (
-            <StatItem key={stat.label} {...stat} delay={i * 0.12} />
+            <StatItem key={`${stat.label}-${stat.end}`} {...stat} delay={i * 0.12} />
           ))}
         </div>
       </div>

--- a/src/lib/githubStars.ts
+++ b/src/lib/githubStars.ts
@@ -1,7 +1,8 @@
 import 'server-only';
 
+import { GITHUB_STARS_FALLBACK, getGitHubStarsFallback, isValidGitHubStars } from '@/lib/githubStarsDisplay';
+
 const GITHUB_REPO_API = 'https://api.github.com/repos/labring/FastGPT';
-const DEFAULT_STARS = 25000;
 const CACHE_FILE = '.cache/github-stars.json';
 
 type GitHubStarsCache = {
@@ -9,17 +10,13 @@ type GitHubStarsCache = {
   updatedAt: number;
 };
 
-function isValidStars(value: unknown): value is number {
-  return typeof value === 'number' && Number.isFinite(value) && value > 0;
-}
-
 async function readStarsCache(): Promise<GitHubStarsCache | null> {
   try {
     const [{ readFile }, path] = await Promise.all([import('fs/promises'), import('path')]);
     const cachePath = path.join(process.cwd(), CACHE_FILE);
     const cache = JSON.parse(await readFile(cachePath, 'utf8')) as GitHubStarsCache;
 
-    if (!isValidStars(cache.stars) || !isValidStars(cache.updatedAt)) {
+    if (!isValidGitHubStars(cache.stars) || !isValidGitHubStars(cache.updatedAt)) {
       return null;
     }
 
@@ -53,7 +50,7 @@ async function fetchGitHubStars(): Promise<number> {
   }
 
   const data = (await response.json()) as { stargazers_count?: unknown };
-  if (!isValidStars(data.stargazers_count)) {
+  if (!isValidGitHubStars(data.stargazers_count)) {
     throw new Error('GitHub API response did not include stargazers_count');
   }
 
@@ -68,6 +65,6 @@ export async function getGitHubStars(): Promise<number> {
     await writeStarsCache(stars);
     return stars;
   } catch {
-    return cache?.stars || DEFAULT_STARS;
+    return getGitHubStarsFallback(cache?.stars || GITHUB_STARS_FALLBACK);
   }
 }

--- a/src/lib/githubStarsClient.ts
+++ b/src/lib/githubStarsClient.ts
@@ -1,3 +1,5 @@
+import { getGitHubStarsFallback } from '@/lib/githubStarsDisplay';
+
 const GITHUB_REPO_API = 'https://api.github.com/repos/labring/FastGPT';
 const CACHE_KEY = 'fastgpt:github-stars';
 
@@ -51,6 +53,6 @@ export async function getCachedGitHubStars(fallback: number): Promise<number> {
     writeStarsCache(data.stargazers_count);
     return data.stargazers_count;
   } catch {
-    return cache?.stars || fallback;
+    return getGitHubStarsFallback(cache?.stars || fallback);
   }
 }

--- a/src/lib/githubStarsDisplay.ts
+++ b/src/lib/githubStarsDisplay.ts
@@ -1,0 +1,19 @@
+export const GITHUB_STARS_FALLBACK = 28000;
+
+export function isValidGitHubStars(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+export function getGitHubStarsFallback(stars?: number) {
+  return isValidGitHubStars(stars) ? Math.max(stars, GITHUB_STARS_FALLBACK) : GITHUB_STARS_FALLBACK;
+}
+
+export function formatGitHubStars(stars?: number) {
+  const displayStars = isValidGitHubStars(stars) ? stars : GITHUB_STARS_FALLBACK;
+  return `${displayStars.toLocaleString()}+`;
+}
+
+export function formatGitHubStarsInThousands(stars?: number) {
+  const displayStars = isValidGitHubStars(stars) ? stars : GITHUB_STARS_FALLBACK;
+  return parseFloat((displayStars / 1000).toFixed(2));
+}


### PR DESCRIPTION
## Summary
- replace stale 25k/26k homepage GitHub star fallbacks with shared display helpers
- move client-side GitHub star refresh above Hero and Stats so both displays update together
- guard server/client fallback paths from stale cached values below 28k

## Verification
- GitHub API checked current labring/FastGPT stars: 28,286
- npm run lint
- npm run build
- local preview checked /zh: Hero shows 28,286+, Stats shows 28.29k