### PR TITLE
[codex] add Rybbit events for nav content links

### DIFF
--- a/src/components/home/Navbar.tsx
+++ b/src/components/home/Navbar.tsx
@@ -24,6 +24,18 @@ function isExternalHref(href: string) {
   return /^(https?:)?\/\//.test(href);
 }
 
+function getNavLinkRybbitAttrs(link: NavLink) {
+  if (link.href.includes('video.fastgpt.cn/videos')) {
+    return rybbitClickAttrs(RYBBIT_EVENTS.learningCenterClick, 'home_nav_learning_center');
+  }
+
+  if (link.href.includes('solutions.fastgpt.cn')) {
+    return rybbitClickAttrs(RYBBIT_EVENTS.caseCenterClick, 'home_nav_case_center');
+  }
+
+  return {};
+}
+
 export default function Navbar({ links = [], t }: { links?: NavLink[]; t: NavCta }) {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [showMobileCta, setShowMobileCta] = useState(true);
@@ -162,6 +174,7 @@ export default function Navbar({ links = [], t }: { links?: NavLink[]; t: NavCta
                   href={getNavHref(link.href, lang)}
                   target={isExternalHref(link.href) ? '_blank' : undefined}
                   rel={isExternalHref(link.href) ? 'noopener noreferrer nofollow' : undefined}
+                  {...getNavLinkRybbitAttrs(link)}
                   className="hover:text-ink transition-colors"
                 >
                   {link.label}
@@ -262,6 +275,7 @@ export default function Navbar({ links = [], t }: { links?: NavLink[]; t: NavCta
                   href={getNavHref(link.href, lang)}
                   target={isExternalHref(link.href) ? '_blank' : undefined}
                   rel={isExternalHref(link.href) ? 'noopener noreferrer nofollow' : undefined}
+                  {...getNavLinkRybbitAttrs(link)}
                   className="py-3 hover:text-ink transition-colors"
                   onClick={() => setMobileOpen(false)}
                 >

--- a/src/lib/rybbitEvents.ts
+++ b/src/lib/rybbitEvents.ts
@@ -1,6 +1,8 @@
 export const RYBBIT_EVENTS = {
   businessConsultClick: 'business_consult_click',
-  cloudServiceClick: 'cloud_service_click'
+  cloudServiceClick: 'cloud_service_click',
+  caseCenterClick: 'case_center_click',
+  learningCenterClick: 'learning_center_click'
 } as const;
 
 type RybbitEventName = (typeof RYBBIT_EVENTS)[keyof typeof RYBBIT_EVENTS];


### PR DESCRIPTION
## What changed

- Added `learning_center_click` for the homepage Learning Center nav link.
- Added `case_center_click` for the homepage Case Center nav link.
- Applies the events to both desktop navigation and the mobile menu.

## Why

The existing Rybbit CTA tracking covers cloud service and business consultation clicks. This adds explicit custom events for the external content navigation links so they are not only tracked as generic outbound clicks.

## Validation

- `npm run lint`
- `npx tsc --noEmit`