### PR TITLE
ci: publish images to GitHub Container Registry

### DIFF
--- a/.github/workflows/fastgpt-home-image.yml
+++ b/.github/workflows/fastgpt-home-image.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
 
 jobs:
   build-fastgpt-landingpage-images:
@@ -31,7 +32,7 @@ jobs:
         with:
           # list of Docker images to use as base name for tags
           images: |
-            registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-home
+            ${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ steps.datetime.outputs.datetime }}
             type=raw,value=latest
@@ -43,14 +44,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Aliyun
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: registry.cn-hangzhou.aliyuncs.com
-          username: ${{ secrets.ALI_HUB_USERNAME }}
-          password: ${{ secrets.ALI_HUB_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker images to ghcr.io and DockerHub
+      - name: Build and push Docker image to GitHub Container Registry
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile
@@ -68,9 +69,9 @@ jobs:
             NEXT_PUBLIC_RYBBIT_TONGJI_SITEID=${{ secrets.NEXT_PUBLIC_RYBBIT_TONGJI_SITEID }}
             NEXT_PUBLIC_CUSTOM_PLAN_URL=${{ secrets.NEXT_PUBLIC_CUSTOM_PLAN_URL }}
             NEXT_PUBLIC_DEFAULT_LOCALE=zh
-            NEXT_PUBLIC_CRM_API_URL=${{ vars.NEXT_PUBLIC_CRM_API_URL }}
+            NEXT_PUBLIC_CRM_API_URL=${{ secrets.NEXT_PUBLIC_CRM_API_URL }}
       - uses: actions-hub/kubectl@master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
-          args: set image deployment/fastgpt-home fastgpt-home=registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-home:${{ steps.datetime.outputs.datetime }}
+          args: set image deployment/fastgpt-home fastgpt-home=${{ env.IMAGE_NAME }}:${{ steps.datetime.outputs.datetime }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           NEXT_PUBLIC_HOME_URL: https://fastgpt.io
           NEXT_PUBLIC_USER_URL: https://cloud.fastgpt.io
-          NEXT_PUBLIC_CRM_API_URL: ${{ vars.NEXT_PUBLIC_CRM_API_URL }}
+          NEXT_PUBLIC_CRM_API_URL: ${{ secrets.NEXT_PUBLIC_CRM_API_URL }}
         run: |
           pnpm install
           pnpm run build


### PR DESCRIPTION
## What changed

- Publish the FastGPT Home image to GitHub Container Registry instead of Aliyun Container Registry.
- Authenticate to GHCR with the workflow-provided `GITHUB_TOKEN`.
- Deploy the timestamped GHCR image to Kubernetes.
- Read `NEXT_PUBLIC_CRM_API_URL` from GitHub Actions secrets in image and preview builds.

## Why

The image build and deployment pipeline should use GitHub's package registry and no longer depend on Aliyun registry credentials. CRM build configuration should also follow the existing secret-based public environment variable setup.

## Impact

Images will be published as `ghcr.io/<owner>/<repository>:<tag>`. After the workflow succeeds, the obsolete `ALI_HUB_USERNAME` and `ALI_HUB_PASSWORD` repository secrets can be removed.

## Validation

- Parsed both modified workflow files as YAML.
- Ran `git diff --check`.
- Confirmed no Aliyun registry references or `vars.NEXT_PUBLIC_CRM_API_URL` references remain in workflows.
