### PR TITLE
fix: preserve attribution params in locale redirect

### DIFF
--- a/src/lib/htmlLang.ts
+++ b/src/lib/htmlLang.ts
@@ -62,7 +62,7 @@ export const htmlLangScript = `
 
     var target = normalize(stored) || browser || defaultLocale;
     if (locales.indexOf(target) !== -1) {
-      window.location.replace('/' + target);
+      window.location.replace('/' + target + window.location.search + window.location.hash);
     }
   }
 })();


### PR DESCRIPTION
## Summary

- preserve the current query string when `/` redirects to a localized route
- preserve the URL hash in the same redirect
- prevent documentation UTM parameters from being dropped before the attribution SDK initializes

## Verification

- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `npm run build`
- verified `/\?utm_source=docs&utm_medium=referral&utm_campaign=docs_getting_started&utm_content=cloud_entry_cn#pricing` redirects with the query and hash intact