### PR TITLE
Localize footer copyright attribution

### DIFF
--- a/src/components/home/Footer.tsx
+++ b/src/components/home/Footer.tsx
@@ -285,18 +285,15 @@ export default function Footer({ t }: { t: FooterT }) {
             style={{ rowGap: 16 }}
           >
             <div className="flex flex-wrap justify-center md:justify-start items-center text-center md:text-left" style={{ columnGap: 24, rowGap: 8 }}>
-              <span style={legalStyle}>
-                {t.copyright} ©{new Date().getFullYear()}{' '}
-                <a
-                  href="https://github.com/labring/FastGPT"
-                  target="_blank"
-                  rel="noopener noreferrer nofollow"
-                  className="hover:opacity-70 transition-opacity"
-                  style={{ color: 'inherit' }}
-                >
-                  labring
-                </a>
-              </span>
+              <a
+                href="https://github.com/labring/FastGPT"
+                target="_blank"
+                rel="noopener noreferrer nofollow"
+                className="hover:opacity-70 transition-opacity"
+                style={{ ...legalStyle, color: 'inherit' }}
+              >
+                {t.copyright.replace('{year}', String(new Date().getFullYear()))}
+              </a>
               {process.env.NEXT_PUBLIC_POLICE_FILING && (
                 <a
                   href="https://beian.mps.gov.cn/"

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -465,7 +465,7 @@
         "feishu": "مجتمع Feishu",
         "group": "مجموعة WeChat"
       },
-      "copyright": "حقوق النشر"
+      "copyright": "© {year} labring. All rights reserved."
     }
   },
   "Enterprise": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -447,7 +447,7 @@
         "feishu": "Feishu Community",
         "group": "WeChat Group"
       },
-      "copyright": "Copyright"
+      "copyright": "© {year} labring. All rights reserved."
     }
   },
   "Enterprise": {

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -465,7 +465,7 @@
         "feishu": "Feishu Community",
         "group": "WeChat Group"
       },
-      "copyright": "Hak Cipta"
+      "copyright": "© {year} labring. All rights reserved."
     }
   },
   "Enterprise": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -447,7 +447,7 @@
         "feishu": "Feishuコミュニティ",
         "group": "WeChatグループ"
       },
-      "copyright": "Copyright"
+      "copyright": "© {year} labring. All rights reserved."
     }
   },
   "Enterprise": {

--- a/src/locales/ms.json
+++ b/src/locales/ms.json
@@ -465,7 +465,7 @@
         "feishu": "Feishu Community",
         "group": "WeChat Group"
       },
-      "copyright": "Hak Cipta"
+      "copyright": "© {year} labring. All rights reserved."
     }
   },
   "Enterprise": {

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -465,7 +465,7 @@
         "feishu": "ชุมชน Feishu",
         "group": "กลุ่ม WeChat"
       },
-      "copyright": "ลิขสิทธิ์"
+      "copyright": "© {year} labring. All rights reserved."
     }
   },
   "Enterprise": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -465,7 +465,7 @@
         "feishu": "Cộng đồng Feishu",
         "group": "Nhóm WeChat"
       },
-      "copyright": "Bản quyền"
+      "copyright": "© {year} labring. All rights reserved."
     }
   },
   "Enterprise": {

--- a/src/locales/zh-hant.json
+++ b/src/locales/zh-hant.json
@@ -465,7 +465,7 @@
         "feishu": "官方社群（飛書）",
         "group": "官方社群（微信）"
       },
-      "copyright": "Copyright"
+      "copyright": "© {year} 广州环际云计算有限公司 版权所有"
     }
   },
   "Enterprise": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -447,7 +447,7 @@
         "feishu": "官方社群（飞书）",
         "group": "官方社群（微信）"
       },
-      "copyright": "Copyright"
+      "copyright": "© {year} 广州环际云计算有限公司 版权所有"
     }
   },
   "Enterprise": {


### PR DESCRIPTION
## Summary

- Localize the homepage footer copyright attribution with a dynamic year placeholder.
- Show Guangzhou Huanji Cloud Computing Co., Ltd. as the copyright holder for Chinese locales.
- Use labring. All rights reserved. for all other locales.

## Impact

The homepage footer now presents the intended copyright holder and a consistent, conventional attribution format across locales.

## Validation

- npx eslint src/components/home/Footer.tsx
- npx tsc --noEmit
- Parsed every locale JSON file and verified the rendered 2026 copyright strings.