### PR TITLE
fix: attach visitor id to cloud entry links

### DIFF
--- a/src/components/home/hooks/useStartUrl.ts
+++ b/src/components/home/hooks/useStartUrl.ts
@@ -1,13 +1,13 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { siteConfig } from '@/config/site';
 import { buildCloudEntryUrl } from '@/lib/cloudEntryUrl';
 
 export function useStartUrl(targetUrl?: string): string {
-  const [url, setUrl] = useState<string>(() => buildCloudEntryUrl('', targetUrl));
+  const [url, setUrl] = useState<string>(targetUrl || siteConfig.userUrl);
 
   useEffect(() => {
-    if (typeof window === 'undefined') return;
     queueMicrotask(() => {
       setUrl(buildCloudEntryUrl(window.location.search, targetUrl));
     });


### PR DESCRIPTION
## Summary
- keep the initial cloud entry URL deterministic during SSR hydration
- append the generated visitor ID after the client mounts
- fix all cloud entry links that share `useStartUrl`

## Verification
- `npx eslint src/components/header/CTAButton.tsx src/components/home/hooks/useStartUrl.ts src/lib/cloudEntryUrl.ts`
- `npm run build`
- verified locally that all cloud entry links contain the same `visitor_id` and no new hydration mismatch is emitted