### PR TITLE
feat: normalize default language URLs across deployments

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -14,9 +14,12 @@ server {
   gzip_min_length 1024;
   gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json image/svg+xml;
 
-  # Canonicalize the default Chinese FAQ URLs on fastgpt.cn.
+  # Canonicalize default Chinese HTML routes on fastgpt.cn.
   # Absolute HTTPS targets avoid downgraded redirects behind the TLS-terminating proxy.
   if ($host ~* ^(?:www\.)?fastgpt\.cn$) {
+      rewrite ^/zh/?$ https://fastgpt.cn/ permanent;
+      rewrite ^/zh/enterprise/?$ https://fastgpt.cn/ permanent;
+      rewrite ^/zh/price/?$ https://fastgpt.cn/price permanent;
       rewrite ^/zh/faq/?$ https://fastgpt.cn/faq permanent;
       rewrite ^/zh/faq/(.+?)/?$ https://fastgpt.cn/faq/$1 permanent;
   }
@@ -27,7 +30,7 @@ server {
   }
 
   # Strip trailing slashes — Next.js uses trailingSlash: false,
-  # so /zh/ should redirect to /zh (which resolves to zh.html).
+  # so localized trailing-slash paths resolve to their extensionless pages.
   # Without this, nginx tries to serve the directory and returns 403.
   location ~ ^(.+)/$ {
       return 301 $1;

--- a/nginx.conf
+++ b/nginx.conf
@@ -22,6 +22,7 @@ server {
       rewrite ^/zh/price/?$ https://fastgpt.cn/price permanent;
       rewrite ^/zh/faq/?$ https://fastgpt.cn/faq permanent;
       rewrite ^/zh/faq/(.+?)/?$ https://fastgpt.cn/faq/$1 permanent;
+      rewrite ^/zh/compare/(.+?)/?$ https://fastgpt.cn/compare/$1 permanent;
   }
 
   # The enterprise appliance page has been retired.

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,15 @@
 /zh/enterprise / 301
+
+# Default English homepage
+/en/ / 301
+/en / 301
+
+# Default English pricing
+/en/price/ /price 301
+/en/price /price 301
+
+# Default English FAQ
+/en/faq/ /faq 301
+/en/faq /faq 301
+/en/faq/*/ /faq/:splat 301
+/en/faq/* /faq/:splat 301

--- a/public/en/llms.txt
+++ b/public/en/llms.txt
@@ -9,7 +9,7 @@ FastGPT is designed for enterprise knowledge base Q&A, AI customer service, inte
 - Website: https://fastgpt.io
 - Documentation: https://doc.fastgpt.io
 - Cloud Service: https://cloud.fastgpt.io
-- Pricing: https://fastgpt.io/en/price
+- Pricing: https://fastgpt.io/price
 - FAQ: https://fastgpt.io/faq
 - Simplified Chinese FAQ: https://fastgpt.io/zh/faq
 - Simplified Chinese LLM Context: https://fastgpt.io/zh/llms.txt
@@ -18,7 +18,7 @@ FastGPT is designed for enterprise knowledge base Q&A, AI customer service, inte
 
 ## Localized Entry Points
 
-- English: https://fastgpt.io/en
+- English: https://fastgpt.io
 - 简体中文: https://fastgpt.io/zh
 - 繁體中文: https://fastgpt.io/zh-hant
 - 日本語: https://fastgpt.io/ja

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,7 +9,7 @@ FastGPT is designed for enterprise knowledge base Q&A, AI customer service, inte
 - Website: https://fastgpt.io
 - Documentation: https://doc.fastgpt.io
 - Cloud Service: https://cloud.fastgpt.io
-- Pricing: https://fastgpt.io/en/price
+- Pricing: https://fastgpt.io/price
 - FAQ: https://fastgpt.io/faq
 - Simplified Chinese FAQ: https://fastgpt.io/zh/faq
 - Simplified Chinese LLM Context: https://fastgpt.io/zh/llms.txt
@@ -18,7 +18,7 @@ FastGPT is designed for enterprise knowledge base Q&A, AI customer service, inte
 
 ## Localized Entry Points
 
-- English: https://fastgpt.io/en
+- English: https://fastgpt.io
 - 简体中文: https://fastgpt.io/zh
 - 繁體中文: https://fastgpt.io/zh-hant
 - 日本語: https://fastgpt.io/ja

--- a/scripts/generate-llms.js
+++ b/scripts/generate-llms.js
@@ -10,6 +10,8 @@ const baseUrl = process.env.NEXT_PUBLIC_HOME_URL || 'https://fastgpt.io';
 const isCn = baseUrl.includes('.cn');
 const publicDir = path.join(__dirname, '../public');
 const englishFallbackLocales = ['ja', 'ar', 'vi', 'th', 'id', 'ms'];
+const englishHomeUrl = isCn ? `${baseUrl}/en` : baseUrl;
+const chineseHomeUrl = isCn ? baseUrl : `${baseUrl}/zh`;
 
 const links = isCn
   ? {
@@ -18,7 +20,7 @@ const links = isCn
       cloud: 'https://cloud.fastgpt.cn',
       pricingEn: 'https://fastgpt.cn/en/price',
       pricingZhHant: 'https://fastgpt.cn/zh-hant/price',
-      pricingZh: 'https://fastgpt.cn/zh/price',
+      pricingZh: 'https://fastgpt.cn/price',
       faqEn: 'https://fastgpt.cn/en/faq',
       faqZh: 'https://fastgpt.cn/faq'
     }
@@ -26,7 +28,7 @@ const links = isCn
       website: 'https://fastgpt.io',
       documentation: 'https://doc.fastgpt.io',
       cloud: 'https://cloud.fastgpt.io',
-      pricingEn: 'https://fastgpt.io/en/price',
+      pricingEn: 'https://fastgpt.io/price',
       pricingZhHant: 'https://fastgpt.io/zh-hant/price',
       pricingZh: 'https://fastgpt.io/zh/price',
       faqEn: 'https://fastgpt.io/faq',
@@ -53,8 +55,8 @@ FastGPT is designed for enterprise knowledge base Q&A, AI customer service, inte
 
 ## Localized Entry Points
 
-- English: ${baseUrl}/en
-- 简体中文: ${baseUrl}/zh
+- English: ${englishHomeUrl}
+- 简体中文: ${chineseHomeUrl}
 - 繁體中文: ${baseUrl}/zh-hant
 - 日本語: ${baseUrl}/ja
 - العربية: ${baseUrl}/ar

--- a/scripts/generate-robots.js
+++ b/scripts/generate-robots.js
@@ -13,7 +13,7 @@ const isCn = baseUrl.includes('.cn');
 const docUrl = isCn ? 'https://doc.fastgpt.cn' : 'https://doc.fastgpt.io';
 const faqUrl = `${baseUrl}/faq`;
 const cloudUrl = isCn ? 'https://cloud.fastgpt.cn' : 'https://cloud.fastgpt.io';
-const priceUrl = isCn ? `${baseUrl}/zh/price` : `${baseUrl}/en/price`;
+const priceUrl = `${baseUrl}/price`;
 const llmsUrl = isCn ? `${baseUrl}/zh/llms.txt` : `${baseUrl}/en/llms.txt`;
 
 // Generate different robots.txt for .cn vs .io domains

--- a/scripts/verify-p0.js
+++ b/scripts/verify-p0.js
@@ -88,11 +88,15 @@ function verifyNginxHeaders() {
   assert.equal(includeCount, 11, 'Security headers must cover the server and all cache locations');
 
   const faqRedirectScope = 'if ($host ~* ^(?:www\\.)?fastgpt\\.cn$) {';
+  const defaultHomeRedirect = 'rewrite ^/zh/?$ https://fastgpt.cn/ permanent;';
+  const defaultPriceRedirect = 'rewrite ^/zh/price/?$ https://fastgpt.cn/price permanent;';
   const faqListRedirect = 'rewrite ^/zh/faq/?$ https://fastgpt.cn/faq permanent;';
   const faqDetailRedirect = 'rewrite ^/zh/faq/(.+?)/?$ https://fastgpt.cn/faq/$1 permanent;';
   const trailingSlashRule = 'location ~ ^(.+)/$ {';
 
   assert(nginxConfig.includes(faqRedirectScope), 'FAQ redirects must be scoped to fastgpt.cn');
+  assert(nginxConfig.includes(defaultHomeRedirect), 'Missing default Chinese home redirect');
+  assert(nginxConfig.includes(defaultPriceRedirect), 'Missing default Chinese price redirect');
   assert(nginxConfig.includes(faqListRedirect), 'Missing permanent FAQ list redirect');
   assert(nginxConfig.includes(faqDetailRedirect), 'Missing permanent FAQ detail redirect');
   assert(
@@ -101,9 +105,37 @@ function verifyNginxHeaders() {
   );
 }
 
+function verifyCloudflareRedirects() {
+  const sourcePath = path.join(rootDir, 'public', '_redirects');
+  const exportedPath = path.join(outDir, '_redirects');
+  const source = fs.readFileSync(sourcePath, 'utf8');
+  const exported = fs.existsSync(exportedPath) ? fs.readFileSync(exportedPath, 'utf8') : '';
+  const requiredRules = [
+    '/en/ / 301',
+    '/en / 301',
+    '/en/price/ /price 301',
+    '/en/price /price 301',
+    '/en/faq/ /faq 301',
+    '/en/faq /faq 301',
+    '/en/faq/*/ /faq/:splat 301',
+    '/en/faq/* /faq/:splat 301'
+  ];
+
+  for (const rule of requiredRules) {
+    assert(source.includes(rule), `Missing Cloudflare Pages redirect: ${rule}`);
+    assert(exported.includes(rule), `Missing exported Cloudflare Pages redirect: ${rule}`);
+  }
+
+  assert(
+    source.indexOf('/en/faq /faq 301') < source.indexOf('/en/faq/* /faq/:splat 301'),
+    'Cloudflare FAQ exact redirect must precede the dynamic redirect'
+  );
+}
+
 async function main() {
   await verifyImage();
   verifyNginxHeaders();
+  verifyCloudflareRedirects();
 
   verifyFaqPage('/faq');
   verifyFaqPage(`/faq/${faqId}`);

--- a/scripts/verify-p0.js
+++ b/scripts/verify-p0.js
@@ -92,6 +92,7 @@ function verifyNginxHeaders() {
   const defaultPriceRedirect = 'rewrite ^/zh/price/?$ https://fastgpt.cn/price permanent;';
   const faqListRedirect = 'rewrite ^/zh/faq/?$ https://fastgpt.cn/faq permanent;';
   const faqDetailRedirect = 'rewrite ^/zh/faq/(.+?)/?$ https://fastgpt.cn/faq/$1 permanent;';
+  const compareDetailRedirect = 'rewrite ^/zh/compare/(.+?)/?$ https://fastgpt.cn/compare/$1 permanent;';
   const trailingSlashRule = 'location ~ ^(.+)/$ {';
 
   assert(nginxConfig.includes(faqRedirectScope), 'FAQ redirects must be scoped to fastgpt.cn');
@@ -99,6 +100,7 @@ function verifyNginxHeaders() {
   assert(nginxConfig.includes(defaultPriceRedirect), 'Missing default Chinese price redirect');
   assert(nginxConfig.includes(faqListRedirect), 'Missing permanent FAQ list redirect');
   assert(nginxConfig.includes(faqDetailRedirect), 'Missing permanent FAQ detail redirect');
+  assert(nginxConfig.includes(compareDetailRedirect), 'Missing permanent comparison detail redirect');
   assert(
     nginxConfig.indexOf(faqRedirectScope) < nginxConfig.indexOf(trailingSlashRule),
     'FAQ redirects must run before the generic trailing-slash redirect'

--- a/scripts/verify-p1.js
+++ b/scripts/verify-p1.js
@@ -106,9 +106,11 @@ function verifyRootMetadata() {
     'Root page title is incorrect'
   );
   verifyCanonical(rootHtml, `${baseUrl}/`);
-  verifyCanonical(localizedHtml, `${baseUrl}/${defaultLocale}`);
-  verifyCanonical(resolveHtml('/en'), `${baseUrl}/en`);
-  verifyCanonical(resolveHtml('/zh'), `${baseUrl}/zh`);
+  verifyCanonical(localizedHtml, `${baseUrl}/`);
+  verifyCanonical(resolveHtml('/en'), `${baseUrl}${defaultLocale === 'en' ? '/' : '/en'}`);
+  verifyCanonical(resolveHtml('/zh'), `${baseUrl}${defaultLocale === 'zh' ? '/' : '/zh'}`);
+  verifyCanonical(resolveHtml('/price'), `${baseUrl}/price`);
+  verifyCanonical(resolveHtml(`/${defaultLocale}/price`), `${baseUrl}/price`);
   verifyCanonical(resolveHtml('/faq'), `${baseUrl}/faq`);
   verifyCanonical(resolveHtml(`/faq/${faqId}`), `${baseUrl}/faq/${faqId}`);
   verifyCanonical(resolveHtml(`/${defaultLocale}/faq`), `${baseUrl}/faq`);
@@ -129,7 +131,7 @@ function verifyRootMetadata() {
       (tag) =>
         getAttribute(tag, 'rel') === 'alternate' &&
         getAttribute(tag, 'hreflang') === 'x-default' &&
-        getAttribute(tag, 'href') === `${baseUrl}/en`
+        getAttribute(tag, 'href') === `${baseUrl}${defaultLocale === 'en' ? '' : '/en'}`
     ),
     'Root page is missing the x-default alternate'
   );

--- a/scripts/verify-p2.js
+++ b/scripts/verify-p2.js
@@ -85,9 +85,11 @@ function verifyHeadingSequence(route, html) {
 }
 
 function getExpectedCanonicalPath(route) {
-  const defaultFaqPrefix = `/${defaultLocale}/faq`;
-  if (route === defaultFaqPrefix || route.startsWith(`${defaultFaqPrefix}/`)) {
-    return route.slice(`/${defaultLocale}`.length);
+  const defaultPrefix = `/${defaultLocale}`;
+  if (route === defaultPrefix) return '/';
+  if (route === `${defaultPrefix}/price`) return '/price';
+  if (route === `${defaultPrefix}/faq` || route.startsWith(`${defaultPrefix}/faq/`)) {
+    return route.slice(defaultPrefix.length);
   }
   return route;
 }
@@ -178,19 +180,23 @@ function verifyAllFaqMetadata() {
   return faqFiles.length;
 }
 
-function verifyFaqMigrationCoverage() {
-  const legacyFaqDir = path.join(outDir, 'zh', 'faq');
+function verifyDefaultLocaleMigrationCoverage() {
+  const legacyLocaleDir = path.join(outDir, defaultLocale);
+  assert(resolveHtml(`/${defaultLocale}`), `Missing legacy ${defaultLocale} home page`);
+  assert(resolveHtml(`/${defaultLocale}/price`), `Missing legacy ${defaultLocale} price page`);
+
+  const legacyFaqDir = path.join(legacyLocaleDir, 'faq');
   const canonicalFaqDir = path.join(outDir, 'faq');
   const legacyFaqFiles = walkHtmlFiles(legacyFaqDir);
 
-  assert(legacyFaqFiles.length > 0, 'No legacy Chinese FAQ detail HTML files found');
+  assert(legacyFaqFiles.length > 0, `No legacy ${defaultLocale} FAQ detail HTML files found`);
 
   for (const legacyFilePath of legacyFaqFiles) {
     const relativePath = path.relative(legacyFaqDir, legacyFilePath);
     const canonicalFilePath = path.join(canonicalFaqDir, relativePath);
     assert(
       fs.existsSync(canonicalFilePath),
-      `Missing canonical FAQ migration target for /zh/faq/${relativePath}`
+      `Missing canonical FAQ migration target for /${defaultLocale}/faq/${relativePath}`
     );
   }
 
@@ -202,6 +208,8 @@ function main() {
     '/',
     '/en',
     '/zh',
+    '/price',
+    `/${defaultLocale}/price`,
     '/faq',
     '/en/faq',
     '/zh/faq',
@@ -238,10 +246,20 @@ function main() {
     assert.deepEqual(levels.slice(0, 3), [1, 2, 3], `${route} must keep h1 -> h2 -> h3 order`);
   }
 
+  const sitemapPath = path.join(outDir, 'sitemap.xml');
+  if (fs.existsSync(sitemapPath)) {
+    const sitemap = fs.readFileSync(sitemapPath, 'utf8');
+    const legacyPrefix = `${baseUrl}/${defaultLocale}`;
+    const legacySitemapUrls = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)]
+      .map((match) => match[1])
+      .filter((url) => url === legacyPrefix || url.startsWith(`${legacyPrefix}/`));
+    assert.equal(legacySitemapUrls.length, 0, 'Sitemap contains default-locale prefixed URLs');
+  }
+
   const faqFileCount = verifyAllFaqMetadata();
-  const migratedFaqFileCount = verifyFaqMigrationCoverage();
+  const migratedFaqFileCount = verifyDefaultLocaleMigrationCoverage();
   console.log(
-    `P2 verification passed for ${baseUrl}: ${faqFileCount} FAQ detail pages checked, ${migratedFaqFileCount} Chinese migration targets matched`
+    `P2 verification passed for ${baseUrl}: ${faqFileCount} FAQ detail pages checked, ${migratedFaqFileCount} ${defaultLocale} migration targets matched`
   );
 }
 

--- a/src/app/price/page.tsx
+++ b/src/app/price/page.tsx
@@ -1,0 +1,1 @@
+export { default, generateMetadata } from '@/app/[lang]/price/page';

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,37 +1,38 @@
 import { MetadataRoute } from 'next';
 import { faq, faqContentLocaleCodes } from '@/faq';
 import { supportedLocaleCodes } from '@/lib/locales';
-import { getFaqPath } from '@/lib/localizedRoutes';
+import { getDefaultLocalePath, getFaqPath } from '@/lib/localizedRoutes';
 
 export const dynamic = 'force-static';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = process.env.NEXT_PUBLIC_HOME_URL || 'https://fastgpt.io';
+  const baseUrl = (process.env.NEXT_PUBLIC_HOME_URL || 'https://fastgpt.io').replace(/\/$/, '');
   const localizedPaths = ['', '/price'];
   const now = new Date();
   const entries: MetadataRoute.Sitemap = [];
+  const seenUrls = new Set<string>();
 
-  // 根首页
-  entries.push({ url: baseUrl, lastModified: now });
+  const addEntry = (url: string, lastModified: Date) => {
+    if (seenUrls.has(url)) return;
+    seenUrls.add(url);
+    entries.push({ url, lastModified });
+  };
 
-  // 各语言的基础页面
   for (const locale of supportedLocaleCodes) {
     for (const path of localizedPaths) {
-      entries.push({ url: `${baseUrl}/${locale}${path}`, lastModified: now });
+      addEntry(`${baseUrl}${getDefaultLocalePath(locale, path)}`, now);
     }
   }
+
   // FAQ 只作为 SEO 页面提交中英文；其他语言 URL 可访问但内容 fallback 到英文
   for (const locale of faqContentLocaleCodes) {
-    entries.push({ url: `${baseUrl}${getFaqPath(locale)}`, lastModified: now });
+    addEntry(`${baseUrl}${getFaqPath(locale)}`, now);
   }
 
   // FAQ 详情页
   for (const locale of faqContentLocaleCodes) {
     for (const faqId of Object.keys(faq)) {
-      entries.push({
-        url: `${baseUrl}${getFaqPath(locale, faqId)}`,
-        lastModified: now
-      });
+      addEntry(`${baseUrl}${getFaqPath(locale, faqId)}`, now);
     }
   }
 

--- a/src/components/header/LangSwitcher.tsx
+++ b/src/components/header/LangSwitcher.tsx
@@ -56,10 +56,7 @@ export const LangSwitcher = ({
   })();
   const isFaqRoute = routeWithoutLang === '/faq' || routeWithoutLang.startsWith('/faq/');
   const languageKeys = isFaqRoute ? faqLocaleCodes : Object.keys(localeNames);
-  const getLocalizedPath = (value: string) => {
-    if (isFaqRoute) return getDefaultLocalePath(value, routeWithoutLang);
-    return routeWithoutLang === '/' ? `/${value}` : `/${value}${routeWithoutLang}`;
-  };
+  const getLocalizedPath = (value: string) => getDefaultLocalePath(value, routeWithoutLang);
 
   const handleSwitchLanguage = (value: string) => {
     if (value === langName) return;

--- a/src/components/home/Navbar.tsx
+++ b/src/components/home/Navbar.tsx
@@ -65,10 +65,7 @@ export default function Navbar({
   })();
   const isFaqRoute = routeWithoutLang === '/faq' || routeWithoutLang.startsWith('/faq/');
   const languageKeys = isFaqRoute ? faqLocaleCodes : Object.keys(localeNames);
-  const getLocalizedPath = (value: string) => {
-    if (isFaqRoute) return getDefaultLocalePath(value, routeWithoutLang);
-    return routeWithoutLang === '/' ? `/${value}` : `/${value}${routeWithoutLang}`;
-  };
+  const getLocalizedPath = (value: string) => getDefaultLocalePath(value, routeWithoutLang);
 
   const handleSwitchLanguage = (value: string) => {
     if (value === lang) return;

--- a/src/lib/localizedRoutes.ts
+++ b/src/lib/localizedRoutes.ts
@@ -5,12 +5,13 @@ export const buildDefaultLocale = normalizeLocale(process.env.NEXT_PUBLIC_DEFAUL
 export function getDefaultLocalePath(locale: string, path = '') {
   const normalizedLocale = normalizeLocale(locale);
   const normalizedPath = path ? (path.startsWith('/') ? path : `/${path}`) : '';
+  const canonicalPath = normalizedPath === '/' ? '' : normalizedPath.replace(/\/$/, '');
 
   if (normalizedLocale === buildDefaultLocale) {
-    return normalizedPath || '/';
+    return canonicalPath || '/';
   }
 
-  return `/${normalizedLocale}${normalizedPath}`;
+  return `/${normalizedLocale}${canonicalPath}`;
 }
 
 export function getFaqPath(locale: string, id?: string) {

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { localeMap, supportedLocaleCodes } from '@/lib/locales';
-import { getFaqPath } from '@/lib/localizedRoutes';
+import { getDefaultLocalePath, getFaqPath } from '@/lib/localizedRoutes';
 
 export { localeMap };
 
@@ -21,18 +21,14 @@ export function getAlternates(
 ): Metadata['alternates'] {
   const baseUrl = getBaseUrl();
 
-  // Canonical should always include the language prefix to avoid duplicate content
-  // This ensures each language version has a unique canonical URL
-  const canonicalPath = `/${lang}${path}`;
-  const canonicalUrl = `${baseUrl}${canonicalPath}`;
+  const canonicalUrl = `${baseUrl}${getDefaultLocalePath(lang, path)}`;
 
   const languages = availableLocales.reduce((acc, locale) => {
-    acc[locale] = `${baseUrl}/${locale}${path}`;
+    acc[locale] = `${baseUrl}${getDefaultLocalePath(locale, path)}`;
     return acc;
   }, {} as Record<string, string>);
 
-  // x-default tells search engines which URL to use for unmatched languages
-  languages['x-default'] = `${baseUrl}/en${path}`;
+  languages['x-default'] = `${baseUrl}${getDefaultLocalePath('en', path)}`;
 
   return {
     canonical: canonicalUrl,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { normalizeLocale, supportedLocaleCodes } from '@/lib/locales';
 import { getDefaultLocalePath } from '@/lib/localizedRoutes';
 
 export function cn(...inputs: ClassValue[]) {
@@ -15,16 +16,22 @@ export function getNavHref(href: string, lang: string): string {
   }
 
   if (href.startsWith('#')) {
-    return `/${lang}${href}`;
+    return `${getDefaultLocalePath(lang)}${href}`;
   }
 
-  if (href === '/faq' || href.startsWith('/faq/')) {
-    return getDefaultLocalePath(lang, href);
+  if (!href.startsWith('/')) {
+    return href;
   }
 
-  if (href.startsWith('/') && !href.startsWith(`/${lang}`)) {
-    return `/${lang}${href}`;
+  const normalizedLang = normalizeLocale(lang);
+  const explicitLocale = supportedLocaleCodes.find(
+    (locale) => href === `/${locale}` || href.startsWith(`/${locale}/`)
+  );
+
+  if (explicitLocale && explicitLocale !== normalizedLang) {
+    return href;
   }
 
-  return href;
+  const routePath = explicitLocale ? href.slice(`/${explicitLocale}`.length) || '/' : href;
+  return getDefaultLocalePath(lang, routePath);
 }


### PR DESCRIPTION
## Summary
- Normalize default-language HTML URLs to root paths on fastgpt.cn and fastgpt.io.
- Add the root pricing route and update SEO, sitemap, robots, LLM index, navigation, and language switching.
- Add host-scoped Nginx 301 rules for fastgpt.cn and Cloudflare Pages _redirects for fastgpt.io.

## Redirect contract
- fastgpt.cn: /zh, /zh/price, /zh/faq and FAQ details redirect to root canonical paths.
- fastgpt.io: /en, /en/price, /en/faq and FAQ details redirect through public/_redirects.
- Query strings are preserved and trailing slashes normalize in one hop.

## Validation
- pnpm lint
- pnpm exec tsc --noEmit
- NEXT_PUBLIC_HOME_URL=https://fastgpt.io NEXT_PUBLIC_DEFAULT_LOCALE=en pnpm build
- NEXT_PUBLIC_HOME_URL=https://fastgpt.cn NEXT_PUBLIC_DEFAULT_LOCALE=zh pnpm build
- P0, P1, and P2 verification passed for both builds.

PR #188 remains unchanged; comparison-page route work stays in that PR.