### PR TITLE
feat: add compare SEO hub and tighten metadata

### DIFF
--- a/content/competitors/en/dify-vs-fastgpt.md
+++ b/content/competitors/en/dify-vs-fastgpt.md
@@ -1,0 +1,130 @@
+<!--
+Delivery metadata (not published with body content)
+slug: dify-vs-fastgpt
+Meta title: Dify vs FastGPT: Plugin Ecosystem vs Knowledge Ops
+Meta description: Compare Dify and FastGPT on plugins, knowledge ops, licensing, channels, and support. Use a same-condition POC to choose with evidence and acceptance criteria.
+keywords: Dify comparison, FastGPT, platform selection, vendor support, open source license
+Structured data: Article + BreadcrumbList (no FAQPage)
+Mapped semantic questions: 31, 32
+Demand basis: dify 81,215 + dify ai 62,240 + Dify Enterprise 5,167 (Dify family total 155,518, real impressions from client Baidu Ads backend, 2026-01-01 to 2026-05-28)
+Sources: client KB 7.1.1 / 7.2.0 / 7.2.1 / 7.3.1 / 7.3.3 / 7.4 / 7.5-05 - 4.3 / 5.4 / 6.3; verified on 2026-07-20
+Internal links: 1. RAGFlow document-parsing comparison 2. Build-vs-buy TCO model 3. Official pricing page
+Schedule: W3 first batch
+Sign-off: messaging review (does not block publishing) - Content is based on the client KB. Before publishing, ask the client to verify: 1. version and capability boundaries 2. commercial messaging 3. naming and wording. If anything is inaccurate, the client can skip this page or request corrections; no signature workflow is required.
+-->
+
+# Dify vs FastGPT: Four Project Profiles and POC Criteria
+
+**Choose Dify when the team depends on a global plugin ecosystem and an overseas collaboration stack. Choose FastGPT when long-term knowledge-base operations, file-based Agents, and Chinese enterprise channels are core constraints.**
+
+Both products provide Cloud, community self-hosting, enterprise paths, Agents, RAG, visual workflows, and two-way MCP. The selection question is where the work sits across plugin ecosystem, knowledge operations, channel delivery, and support responsibility.
+
+---
+
+## 1. Product Focus: Plugin Ecosystem and Knowledge Engineering
+
+**Dify focuses on general orchestration and a plugin ecosystem.** Its official plugin repository, creator center, template marketplace, and international community are more mature. Public materials for the Enterprise path clearly list SAML/OIDC SSO, SCIM, tamper-proof audit logs, and SIEM streaming output. The breadth of general database plugins and model plugins, plus its brand presence among overseas developers, are real advantages. These strengths are immediately useful for organizations that rely first on ready-made plugins, have teams distributed overseas, or buy in a global ecosystem context.
+
+**FastGPT focuses on knowledge-engineering depth and a closed delivery loop for Chinese enterprises.** Its product paths cover Cloud, community self-hosting, and managed or self-hosted commercial editions. Its native channel coverage includes WeCom, WeChat Official Accounts, personal WeChat, Feishu, DingTalk, and iframe. Local multi-model access is already supported. FastGPT puts RAG inside a more complete runtime, allowing Agentic RAG, interactive state recovery, Skills, and knowledge engineering to work together in the same orchestration layer.
+
+**Selection signal**: Prioritize Dify validation when plugin breadth, overseas collaboration stacks, and a global ecosystem are the primary constraints. Prioritize FastGPT validation when long-term knowledge-base maintenance, file-based Agents, the Skills lifecycle, and Chinese channel delivery are the primary constraints. In production, the difference is concentrated in how maintenance, operations, and delivery responsibility are divided.
+
+---
+
+## 2. Capability Differences: What Affects Production
+
+### 2.1 FastGPT's Differentiated Capabilities
+
+| # | Capability | Specific scope | Comparison result |
+|---|---|---|---|
+| 01 | **Stable Skills lifecycle** | Import/export, versions, permission inheritance, reference analysis, editing sandbox, and runtime sandbox | The officially supported scope of Dify Agent Skills should enter POC confirmation |
+| 02 | **Agent session file workspace** | File tree, multi-tab editor, interactive terminal, directory ZIP, and session sandbox artifact return | Equivalent native capability should enter POC confirmation |
+| 03 | **Image knowledge base and original-image vector retrieval chain** | Stores original images, VLM captions, and imageEmbedding at the same time; supports image-to-image search and caption fallback | Equivalent native capability should enter POC confirmation |
+| 04 | **Finer-grained knowledge-data maintenance chain** | One body with multiple indexes, independent index editing, training queue repair, retrieval history, token cost split by stage, and fine-grained citation tracing | Equivalent granularity should enter POC confirmation |
+
+**Production impact**: These capabilities determine the operating cost of the knowledge base: locating chunking, indexing, and retrieval configuration issues; attaching multiple indexes to one body; repairing a single failed training item; splitting parsing, vectorization, retrieval, and generation costs. Differences that look small in a demo appear clearly during continuous operations.
+
+### 2.2 Shared Capabilities With Different Implementation Paths
+
+| Capability | Dify implementation path | FastGPT implementation path |
+|---|---|---|
+| Agent + RAG + visual workflow + two-way MCP | Centered on general workflows and the plugin ecosystem | Emphasizes Agentic RAG, interactive state recovery, Skills, and knowledge engineering in one runtime |
+| Complex document parsing | Often relies on plugin pipelines such as LlamaParse and Mistral OCR | Provides local LiteParse / PDF.js paths plus enhanced TextIn / Doc2x paths |
+| Open API and web publishing | SSE, API, web app, and embedding | Same, plus OpenAI SDK compatibility, native Chinese IM channels, and reverse publishing an app as an MCP Server |
+| Enterprise governance (RBAC / SSO / multi-tenancy / audit) | Enterprise provides RBAC, SAML/OIDC, SCIM, tamper-proof audit and SIEM, multi-workspace / multi-tenancy | Commercial editions provide ABAC + RBAC, SSO, multi-tenancy, and an admin console; advanced cloud plans publicly list 720-day team operation logs |
+
+> **Acceptance condition**: Use the same dataset, model, hardware, concurrency, and permission matrix, then record each result. For enterprise governance, also verify members, workspaces, resources, log retention, and the version that includes external IdP integration.
+
+### 2.3 Where Dify Has an Advantage
+
+- **Global plugins and Marketplace ecosystem**: The official plugin repository, creator center, template marketplace, and international community are more mature.
+- **Enterprise identity and audit integration**: Public materials clearly list SAML/OIDC SSO, SCIM, tamper-proof audit logs, and SIEM streaming output.
+- **Breadth of general database and model plugins**: The official Marketplace path is more direct, making it useful for teams that rely first on ready-made plugins.
+- **International brand and developer mindshare**: Dify has a stronger position among overseas developers and global ecosystem buyers.
+
+When plugin breadth and overseas collaboration are the first project constraints, include Dify in the final POC and record implementation cost across installation, authentication, debugging, version locking, and troubleshooting for the key integrations.
+
+---
+
+## 3. Licensing and Support: Procurement Boundaries and Responsibility
+
+Licensing determines SaaS operation, de-branding, secondary development distribution, and private deployment boundaries. Legal should review the LICENSE item by item across these four areas and write the result into the procurement and delivery checklist.
+
+| Item | Dify | FastGPT |
+|---|---|---|
+| Product path | Cloud + Community + Enterprise | Cloud + community self-hosting + managed / self-hosted commercial editions |
+| Open source license | Modified Apache 2.0; using source code to provide multi-tenant services or removing frontend branding requires commercial authorization | FastGPT Open Source License: allows commercial use as a backend service provider for other applications and as an application development platform delivered to enterprises; written authorization is required to operate a similar multi-tenant SaaS with the source code or to remove/modify the LOGO and copyright information in the console |
+| Self-hosted deployment method | Community uses Docker Compose; Enterprise uses Helm | Docker Compose, with multiple vector backends supported; Kubernetes commercial delivery boundaries require confirmation |
+| Private / offline | Enterprise supports VPC, local, and fully isolated deployment | Commercial editions support private deployment and fully offline operation |
+| Procurement model | Cloud free tier + two annual workspace subscriptions; Enterprise quote-based, SLA by contract | Cloud has a free tier and two monthly subscriptions; managed commercial edition starts monthly; private deployment uses per-server licenses in Standard / Professional / Ultimate versions. Selection order: tenant count -> SSO and OA integration needs -> independent invoicing and payment module needs |
+| Vendor support | Enterprise path is quote-based, SLA by contract; whether the community edition includes support commitments requires confirmation with Dify | Four support tiers, with coverage expanding from business days to 7x24 and first-response targets increasing by tier; all paid tiers include security patches, new feature support, and remote online assistance; paid tiers include a dedicated support group, and the highest tier adds an account manager; private deployment delivery can include installation, debugging, and vendor technical maintenance |
+
+The buyer should put subscription or license, implementation, maintenance, model usage, infrastructure, and operations into a three-year TCO. Use same-day written quotes from both sides, and record tax basis and authorization period together.
+
+The procurement checklist should require both vendors to provide a responsibility matrix, incident levels, recovery targets, upgrade/rollback owners, and exit/migration terms. Record first-response targets separately from repair time limits. Final commitments should be based on contract terms.
+
+The full FastGPT application consists of community edition images and commercial edition images. Commercial edition images require a license to start. Agent-assisted generation, Skill professional assisted generation, and local/remote debugging of system tools are commercial edition and cloud service capabilities. For small teams using the system internally while taking on deployment, upgrades, backup, and security themselves, the community edition can be assessed first. When SSO, multi-tenancy, audit, long-retention logs, commercial support, or an explicit SLA enter the requirement list, include the commercial edition in the procurement comparison.
+
+---
+
+## 4. POC Validation: Compare With the Same Data
+
+Put both options into the same POC environment. Fix the golden set, Embedding, ReRank, LLM, TopK, hardware, and concurrency, then record metrics and evidence artifacts.
+
+| Category | Required metrics | Unified conditions | Evidence artifact |
+|---|---|---|---|
+| RAG quality | Recall@K, MRR / NDCG, citation accuracy, hallucination rate, no-answer refusal rate | Same golden question set, Embedding, ReRank, LLM, TopK | Replayable test set + per-question results |
+| Complex documents | Table / heading / page number / image fidelity, parsing success rate, time and cost per 100 pages | Same scanned files, contracts, research reports, PPTX, XLSX | Diff between source and parsed result + manual sampling |
+| Online performance | P50 / P95 / P99 latency, success rate, requests per second, peak concurrency | Same model endpoint, vector database, machine type, data volume, and warm-up method | Load test script, raw report, resource curves |
+| Reliability | Node failure recovery, retry idempotency, queue backlog, upgrade rollback, backup recovery | Same fault-injection script and data scale | Incident timeline, lost/duplicate records, recovery time |
+| Security and governance | Privilege escalation, SSRF, secret leakage, sandbox escape, tenant isolation, audit coverage | Same threat cases and permission matrix | Case results, audit records, remediation items |
+| Three-year TCO | License, model, parsing / OCR, storage, database, operations, upgrades, and support | Unified three-year business growth assumptions | Three-year cash flow + person-days + risk reserve |
+
+Validate the plugin ecosystem with a project checklist: choose the 5-10 integrations the enterprise uses most often, then record the actual time for installation, authentication, debugging, version locking, and troubleshooting.
+
+Put the following metrics into the "not publicly listed / POC required / contract required" checklist: steady-state and peak concurrency, requests per second, token throughput per minute, parsing and retrieval latency under specified hardware, maximum application and knowledge-base counts, availability SLA and RTO / RPO, full API coverage by version, and real-time plugin count.
+
+---
+
+## 5. Selection Recommendations: Decide by Project Constraints
+
+| First success factor for the project | Recommendation |
+|---|---|
+| Ready-made plugin breadth, overseas collaboration stack, global ecosystem procurement | **Dify should enter the final candidate set**, with implementation cost compared through the POC table |
+| Long-term knowledge-base maintenance cost (multiple indexes, training queue, citation tracing, cost split) | FastGPT's knowledge-data maintenance chain is more granular, and the advantage becomes clearer during operations |
+| Agents need real file operations and artifact return inside the session | FastGPT's Agent session file workspace is a verifiable difference |
+| Chinese enterprise channel publishing (Feishu, DingTalk, WeCom, Official Account, personal WeChat) | FastGPT covers these channels natively, reducing the need for a custom channel adapter layer |
+| Start with low-cost validation, then migrate to a private environment | FastGPT has a complete Cloud-to-private delivery path, so teams can validate first and migrate later |
+| Strict external sync + department information isolation + strong audit and cost management | Verify version boundaries item by item on both sides, and write the combined requirements into the contract and acceptance checklist |
+| Response coverage, recovery responsibility, and upgrade rollback must be written into the contract | Ask both sides for a responsibility matrix and service checklist. FastGPT's support tier structure is public; Dify Enterprise SLA is contract-confirmed |
+
+Accuracy, performance, data egress, and SLA should be confirmed through same-condition POC, data-flow inventory, and contract terms. For private deployment, list outbound paths for external models, OCR, plugins, connectors, version updates, and telemetry item by item.
+
+---
+
+> **Sources**: Dify and FastGPT official websites, official documentation, official repositories, official pricing pages, and public release records
+> **Verification date**: 2026-07-20
+> **Versions and plans**: Dify Cloud / Community / Enterprise; FastGPT Cloud / community self-hosting / managed and self-hosted commercial editions. Capability status in this article is based on stable official public materials available on the verification date; experimental and pre-release branches are excluded
+> **Update record**: V1.2 (2026-08-08) rewrote visible copy while preserving facts on capabilities, licensing, support, and POC. Pricing, version numbers, templates, plugin counts, and Cloud quotas use a 90-day review cycle
+
+> **Update record addendum**: On 2026-08-08, page framing and body copy were unified around applicable scenarios, production differences, contract responsibility, and same-condition POC. Evidence remains stored in delivery metadata and the manifest.

--- a/content/competitors/en/maxkb-vs-fastgpt.md
+++ b/content/competitors/en/maxkb-vs-fastgpt.md
@@ -1,0 +1,163 @@
+<!--
+Delivery metadata (not published with body content)
+slug: maxkb-vs-fastgpt
+Meta title: MaxKB vs FastGPT: Procurement vs Production Control
+Meta description: Compare MaxKB and FastGPT on private deployment, governance, support tiers, and three-year TCO before procurement. Confirm terms with a same-condition POC.
+keywords: MaxKB comparison, FastGPT, private deployment, three-year TCO, code sandbox
+Structured data: Article + BreadcrumbList (no FAQPage)
+Mapped semantic questions: 31, 35
+Demand basis: This brand has very low impressions in the client Baidu account, but appears frequently in domestic private-deployment procurement comparisons (KB 7.1.2: "will directly enter domestic procurement comparison")
+Sources: client KB 7.1.2 / 7.2.0 / 7.2.2 / 7.3.1 / 7.3.3 / 7.4 / 7.5-07 - 5.4 / 6.3; verified on 2026-07-20
+Internal links: 1. Build-vs-buy TCO model 2. RAGFlow document-parsing comparison 3. Official pricing page
+Schedule: W4
+Sign-off: messaging review (does not block publishing) - Content is based on the client KB. Before publishing, ask the client to verify: 1. version and capability boundaries 2. commercial messaging 3. naming and wording. If anything is inaccurate, the client can skip this page or request corrections; no signature workflow is required.
+-->
+
+# MaxKB vs FastGPT: Procurement Predictability and Production Granularity
+
+**Include MaxKB as a candidate when private delivery and procurement predictability come first. Prioritize FastGPT when fine-grained knowledge governance, workflow recovery, and multi-channel operations come first.**
+
+Both products emphasize open source, private deployment, knowledge bases, workflows, and Agents. Procurement model, production capability granularity, and vendor support responsibility should be reviewed by procurement, technical, and security teams respectively.
+
+---
+
+## 1. Product Focus: Private Procurement and Production Granularity
+
+**MaxKB focuses on a straightforward domestic private-delivery model.** The offline installation path is clear. Professional and Enterprise authorization models, next-year maintenance, and vendor support tiers are public on the official website, with support divided into 5x8 and 7x24 levels. One-time authorization helps internal approval. The database query tool is clearly listed in official documentation, giving the product strong visibility. Projects that want "install and use, report the budget once" fit this product shape well.
+
+**FastGPT focuses on fine-grained control in complex production scenarios.** Isolated code sandboxing, manual workflow pause and in-place recovery, unified quotas and usage governance, image vectors, multi-index retrieval, and cost explanation all point to one production question: when the system runs in real business for a long time, can problems be located, can humans intervene, and can costs be explained? FastGPT also keeps three paths: Cloud, community self-hosting, and managed / self-hosted commercial editions, allowing teams to validate at low cost before migrating to a private environment.
+
+One-time authorization, maintenance ratio, and support tiers make budget approval more intuitive. Three-year total cost should also include hardware, model consumption, implementation person-days, cluster expansion, and feature customization. The three-year TCO table should include all of these costs.
+
+---
+
+## 2. Capability Differences: Governance, Workflow, and Retrieval
+
+### 2.1 FastGPT's Differentiated Capabilities
+
+| # | Capability | Specific scope | Comparison result |
+|---|---|---|---|
+| 01 | **Isolated code sandbox** | Public materials clearly describe isolated JavaScript / Python execution plus network and file restrictions | Independent sandbox should enter POC confirmation |
+| 02 | **Manual workflow pause and in-place recovery** | Supports user selection and multi-field forms, preserving state through sub-apps, tools, and loops before resuming | Human confirmation nodes should enter POC confirmation |
+| 03 | **Unified quota and usage governance** | API Key and share-link quotas, expiry, QPM, plus cloud plan resource quotas | Unified quota management should enter POC confirmation |
+| 04 | **Image vectors, multiple indexes, and retrieval cost explanation** | imageEmbedding, caption fallback, weighted RRF, retrieval-stage scores, and token split | Retrieval cost split granularity should enter POC confirmation |
+
+**Production impact**:
+
+- For **isolated sandboxes**, security review should focus on network access, file access, process isolation, and audit traces. Runtime architecture determines the isolation boundary.
+- **Manual pause and in-place recovery** lets AI enter approval workflows. The POC should record pause behavior, state persistence, and recovery path.
+- **Unified quotas** control share-link and API Key usage. Cost split helps locate parsing, vectorization, retrieval, and generation cost.
+- **Image vectors and cost explanation** cover chart and screenshot retrieval plus stage-level cost for each Q&A.
+
+### 2.2 Shared Capabilities With Different Implementation Paths
+
+| Capability | MaxKB implementation path | FastGPT implementation path |
+|---|---|---|
+| Knowledge base, Agent, visual workflow, Skills, MCP | Covered, with more emphasis on quick knowledge-base onboarding and tool extension | Covered, with more emphasis on independent tool types, Skill sandboxes, and two-way MCP |
+| Documents and structured data | Supports Office / PDF / tables, extendable through OCR, MinerU, and other tools | Supports similar formats, while emphasizing local parsing, image indexes, and training queues |
+| Enterprise governance | Professional edition provides RBAC, SSO, and operation logs; multi-tenancy and clustering are clearly placed in Enterprise | Commercial editions provide ABAC + RBAC, SSO, multi-tenancy, and an admin console; advanced cloud plans publicly list 720-day team operation logs |
+| Deployment and channels | Docker, offline deployment, Web / API, and domestic IM; shape is closer to a standard private-deployment product | Docker Compose, multiple vector backends, plus Cloud, community self-hosting, and commercial delivery |
+
+> **Acceptance condition**: For enterprise governance, fix organization, department, group, resource, log retention, and operation-type permission cases. Record multi-tenancy and cluster version boundaries in the POC.
+
+### 2.3 Where MaxKB Has an Advantage
+
+- **Straightforward domestic private-delivery form**: Offline installation path, authorization model, next-year maintenance, and vendor support tiers are public on the official website.
+- **Procurement predictability**: One-time authorization and public support tiers simplify budget approval. Maintenance, implementation, models, and hardware still enter three-year TCO.
+- **Product visibility of the database query tool**: The official documentation clearly lists a database query tool. FastGPT's general path mainly uses HTTP API and tool wrapping, which is more open and adds an integration layer.
+- **Public support tiers**: Professional 5x8 and Enterprise 7x24 are more intuitive for buyers. Specific response and recovery targets should still be based on the contract.
+
+---
+
+## 3. Procurement Boundaries: License, Buyout, and Support Tiers
+
+### 3.1 Public Boundaries on Both Sides
+
+| Item | MaxKB | FastGPT |
+|---|---|---|
+| Product path | Community self-hosting + Professional / Enterprise | Cloud + community self-hosting + managed / self-hosted commercial editions |
+| Open source license | GPLv3; X-Pack commercial boundaries require separate confirmation | FastGPT Open Source License: allows commercial use as a backend service provider for other applications and as an application development platform delivered to enterprises; written authorization is required to operate a similar multi-tenant SaaS with the source code or to remove/modify the LOGO and copyright information in the console |
+| Public minimum self-hosted infrastructure | At least 4 cores / 8GB / 100GB | No fixed unified minimum CPU / memory, sizing is based on vector database, document volume, model, and concurrency |
+| Deployment method | Docker; Enterprise supports clusters | Docker Compose, with multiple vector backends supported; Kubernetes commercial delivery boundaries require confirmation |
+| Private / offline | Community edition can be deployed offline and self-hosted; Professional and Enterprise include vendor support | Commercial editions support private deployment and fully offline operation |
+| Procurement model | Professional edition one-time perpetual authorization + next-year maintenance; Enterprise quote-based | Cloud has free and two monthly subscriptions; managed commercial edition starts monthly; private deployment uses per-server licenses in Standard / Professional / Ultimate versions |
+| Vendor support tiers | Professional 5x8, Enterprise 7x24; availability and RTO / RPO require contract confirmation | Four support tiers, with coverage expanding from business days to 7x24 and first-response targets increasing by tier; all paid tiers include security patches, new feature support, and remote online assistance; paid tiers include a dedicated support group, and the highest tier adds an account manager; private deployment delivery can include installation, debugging, and vendor technical maintenance; concrete availability and recovery metrics require contract confirmation |
+
+GPLv3 and the FastGPT Open Source License create different constraint profiles: distribution, derivative works, multi-tenant SaaS operation, and de-branding boundaries should each enter the legal checklist. X-Pack commercial boundaries need written confirmation.
+
+Internal enterprise use and external delivery should separately list secondary development ownership, distribution obligations, de-branding rights, and multi-customer service model, then check each LICENSE against the actual delivery path.
+
+Authorization price, maintenance ratio, subscription price, and plan boundaries should use same-day written quotes from both sides. Record tax basis, authorization period, and implementation/maintenance scope together.
+
+The procurement checklist should require a responsibility matrix, incident levels, recovery targets, and upgrade/rollback owners. Record first-response targets separately from repair time limits. For buyout models, additionally confirm whether next-year maintenance keeps the same service coverage. Final commitments should be based on the contract.
+
+### 3.2 Three-Year TCO for Buyout and Subscription
+
+Compare buyout and subscription under the same three-year scale. The cost table should record license, maintenance, hardware, model usage, implementation, cluster, upgrade, secondary development, and risk reserve:
+
+| Cost item | Explanation |
+|---|---|
+| License / subscription | Buyout side is first-year authorization; subscription side is three-year subscription. Use each side's official same-day real price |
+| Second- and third-year maintenance | The key variable for buyout models, which must be included in years two and three |
+| Hardware | Convert minimum resource requirements into actual server or cloud-host cost, including storage and backup |
+| Model consumption | Vectorization and generation, estimated by real Q&A volume, with the same assumptions on both sides |
+| Implementation | Person-days for deployment, debugging, knowledge-base construction, and permission configuration |
+| Cluster | Whether multiple nodes are required, and whether multiple nodes require additional authorization |
+| Upgrades | Three-year version upgrade path and whether extra fees apply |
+| Feature customization | Person-days to fill missing capabilities, including long-term maintenance |
+| Risk cost | Rework caused by version boundary mismatch, migration cost, or failed review |
+
+**The output is a three-year TCO table**, plus sensitivity analysis for member count, document volume, request volume, and dual-node requirements.
+
+The subscription-vs-buyout conclusion should be based on a same-scope three-year table. Record scale, growth assumptions, and internal budgeting model together.
+
+---
+
+## 4. POC Validation: Combine Three-Year Cost and Failure Drills
+
+In addition to the unified POC measurement table, add three test groups for sandboxing, human recovery, and quota cost:
+
+| Extra test | Specific method | Criterion |
+|---|---|---|
+| **Sandbox and tool security** | Run code in a tool node that tries to access the external network and read/write local files; then try privilege escalation and secret reading | Whether isolation blocks it; whether failure affects the main process; whether the audit trail records it |
+| **Human confirmation inside a process** | Design a process that needs a human to fill a multi-field form mid-flow, with that node inside a sub-app or loop | Whether it can resume in place and preserve state after pause, or must rerun from the beginning |
+| **Quota and cost explainability** | Publish a share link, set quota and expiry, run a batch of Q&A, then inspect cost | Whether quota and QPM take effect; whether cost can be split into parsing, vectorization, retrieval, and generation stages |
+
+Complete unified POC measurement table:
+
+| Category | Required metrics | Unified conditions | Evidence artifact |
+|---|---|---|---|
+| RAG quality | Recall@K, MRR / NDCG, citation accuracy, hallucination rate, no-answer refusal rate | Same golden question set, Embedding, ReRank, LLM, TopK | Replayable test set + per-question results |
+| Complex documents | Table / heading / page number / image fidelity, parsing success rate, time and cost per 100 pages | Same scanned files, contracts, research reports, PPTX, XLSX | Diff between source and parsed result + manual sampling |
+| Online performance | P50 / P95 / P99 latency, success rate, requests per second, peak concurrency | Same model endpoint, vector database, machine type, data volume, and warm-up method | Load test script, raw report, resource curves |
+| Reliability | Node failure recovery, retry idempotency, queue backlog, upgrade rollback, backup recovery | Same fault-injection script and data scale | Incident timeline, lost/duplicate records, recovery time |
+| Security and governance | Privilege escalation, SSRF, secret leakage, sandbox escape, tenant isolation, audit coverage | Same threat cases and permission matrix | Case results, audit records, remediation items |
+| Three-year TCO | See 3.2 | Unified three-year business growth assumptions | Three-year cash flow + person-days + risk reserve |
+
+Put the following metrics into the "not publicly listed / POC required / contract required" checklist: steady-state and peak concurrency, requests per second, token throughput per minute, parsing and retrieval latency under specified hardware, maximum application and tenant counts, availability SLA and RTO / RPO, and real-time template and plugin counts.
+
+---
+
+## 5. Selection Recommendations: Decide by Budget Basis and Delivery Responsibility
+
+| First constraint for the project | Recommendation |
+|---|---|
+| The budget needs to be reported once, and internal approval prefers one-time authorization | **MaxKB will directly enter price comparison**, calculated through the three-year table in 3.2 |
+| Offline installation path and support tiers need to be clear before procurement | MaxKB's public model is more intuitive |
+| A ready-made database query tool is required and an added integration layer is unwanted | MaxKB has stronger product visibility |
+| Tool nodes must execute code and pass security review | Isolated sandboxing is a verifiable difference, and FastGPT public materials describe it clearly |
+| Business flows require human confirmation in the middle, with the node inside a subflow or loop | Manual pause and in-place recovery determine whether this scenario can go live |
+| Share-link and API usage must be controlled, with cost visible by stage | Unified quotas and cost split are verifiable differences |
+| Information inside charts and screenshots needs to be retrievable | Image vectors and multi-index retrieval are verifiable differences |
+| Low-cost validation should happen first, followed by migration to a private environment | FastGPT has a complete Cloud-to-private path |
+
+Security, reliability, and accuracy should be confirmed through unified POC and contract acceptance. Controls that are not covered should enter the supplemental test checklist.
+
+---
+
+> **Sources**: MaxKB and FastGPT official websites, official documentation, official repositories, official pricing pages, and public release records
+> **Verification date**: 2026-07-20
+> **Versions and plans**: MaxKB community self-hosting / Professional / Enterprise; FastGPT Cloud / community self-hosting / managed and self-hosted commercial editions
+> **Update record**: V1.2 (2026-08-08) rewrote visible copy while preserving facts on procurement, governance, support responsibility, and POC. Authorization price, maintenance, version numbers, and support tiers use a 90-day review cycle
+
+> **Update record addendum**: On 2026-08-08, page framing and body copy were unified around applicable scenarios, production differences, contract responsibility, and same-condition POC. Evidence remains stored in delivery metadata and the manifest.

--- a/content/competitors/en/ragflow-vs-fastgpt.md
+++ b/content/competitors/en/ragflow-vs-fastgpt.md
@@ -1,0 +1,147 @@
+<!--
+Delivery metadata (not published with body content)
+slug: ragflow-vs-fastgpt
+Meta title: RAGFlow vs FastGPT: Complex Docs vs Delivery Chain
+Meta description: Compare RAGFlow and FastGPT on document parsing, knowledge ops, workflow recovery, channels, and support before a same-document POC with your own rubric.
+keywords: RAGFlow comparison, FastGPT, complex document parsing, golden-set validation, open source license
+Structured data: Article + BreadcrumbList (no FAQPage)
+Mapped semantic questions: 25, 31
+Demand basis: ragflow 3,834 + ragflow [deleted] 6,216 + long-tail terms such as RAGFlow and Dify comparison around 10,050 (real impressions from client Baidu Ads backend, 2026-01-01 to 2026-05-28)
+Sources: client KB 7.1.3 / 7.2.0 / 7.2.3 / 7.3.1 / 7.3.3 / 7.4 / 7.5-06 - 5.4 / 6.3; verified on 2026-07-20
+Internal links: 1. Dify plugin-ecosystem comparison 2. Build-vs-buy TCO model 3. MaxKB procurement comparison
+Schedule: W4
+Sign-off: messaging review (does not block publishing) - Content is based on the client KB. Before publishing, ask the client to verify: 1. version and capability boundaries 2. commercial messaging 3. naming and wording. If anything is inaccurate, the client can skip this page or request corrections; no signature workflow is required.
+-->
+
+# RAGFlow vs FastGPT: Complex Documents and the Full Delivery Chain
+
+**Prioritize RAGFlow validation when scanned files and complex-layout parsing are the primary job. Prioritize FastGPT when knowledge operations, workflow recovery, Chinese channels, and vendor support become core constraints.**
+
+RAGFlow centers on deep document understanding and extends into Agents, MCP, Skills, connectors, and Cloud / Enterprise paths. FastGPT places RAG inside a complete chain of Agents, workflows, channel publishing, and operational governance. Parsing quality, application development time, and support responsibility should be confirmed together through a same-condition POC and contract checklist.
+
+---
+
+## 1. Product Focus: Complex Documents and Knowledge Operations
+
+**RAGFlow focuses on deep document understanding.** Parsing complex layouts and scanned documents is its signature strength: deep document understanding, adjustable chunking, and scanned-document OCR form a clear product position. Its public release records list multi-source incremental sync connectors such as Confluence, S3, Notion, Discord, and Google Drive, which is directly attractive to overseas collaboration stacks. Its Apache-2.0 license is more permissive for buyers that care about secondary development, internal platformization, and avoiding proprietary cloud lock-in. Public docs clearly support Langfuse tracing, including retrieval, ranking, generation, prompts, and responses, which is an immediate gain for teams already using Langfuse.
+
+**FastGPT focuses on putting RAG into a more complete operating system.** It also provides hybrid retrieval, ReRank, traceable citations, image understanding, and multi-model support, but places them inside a complete chain of Agents, workflows, channel publishing, and operational governance, with native coverage for Chinese enterprise knowledge sources and publishing channels.
+
+**Selection signal**: Prioritize RAGFlow validation when converting hard-to-parse documents into knowledge is the primary task. Prioritize FastGPT validation when knowledge, Agents, automation, and channel operations need to work together over the long term.
+
+Self-hosting resource requirements should go directly into the budget. RAGFlow publicly lists a minimum of 4 cores / 16GB / 50GB, Docker 24, Compose 2.26.1, and x86 prebuilt images. FastGPT sizing depends on vector database, document volume, model deployment method, and concurrency. If fixed server specs or domestic infrastructure constraints already exist, complete resource planning and architecture review in the first POC week.
+
+---
+
+## 2. Capability Differences: Parsing, Retrieval, and the Full Chain
+
+### 2.1 FastGPT's Differentiated Capabilities
+
+| # | Capability | Specific scope | Comparison result |
+|---|---|---|---|
+| 01 | **Built-in scheduled automation** | Configure Cron, timezone, and default questions for published apps | Built-in time / event scheduler should enter POC confirmation |
+| 02 | **Admin audit and unified quota loop** | Commercial editions and Cloud publicly list operation logs, API Key and share-link limits, and QPM | Admin audit logs and unified quotas should enter POC and contract confirmation |
+| 03 | **Continuous website sync and Chinese knowledge sources** | Website sync, plus Feishu, Yuque, DingTalk, and custom API knowledge sources | Continuous website / sitemap crawling should enter POC confirmation |
+| 04 | **Chinese enterprise publishing and operations loop** | Native Feishu, DingTalk, WeCom, WeChat Official Account, and personal WeChat, plus user feedback, session labeling, app evaluation, and operations dashboards | Chinese channels and operations loop should enter POC confirmation |
+
+These capabilities directly affect post-launch operations: scheduled cleanup, admin audit, Feishu and Yuque sync, WeCom Q&A, session labeling, and evaluation feedback should all enter the acceptance checklist.
+
+### 2.2 Shared Capabilities With Different Implementation Paths
+
+| Capability | RAGFlow implementation path | FastGPT implementation path |
+|---|---|---|
+| Complex-document RAG | Deep document understanding is the product center, with hybrid retrieval, ReRank, traceable citations, image understanding, and multi-model support | Provides the same capability set, while placing RAG inside a more complete Agent / workflow / operations system |
+| Agents, workflows, MCP, Skills, human wait | Covered; Skills Space is on the main branch, and formal release boundaries require written confirmation | Provides a more complete Skill version, permission, and sandbox chain |
+| Code / database tools | Official Execute SQL component; code execution can be configured with gVisor | General HTTP wrapping, separated secrets, SSRF protection, and isolated process pools |
+| Cloud / self-hosted / enterprise paths | All three paths exist; self-hosting requirements are higher and explicit (minimum 4 cores / 16GB / 50GB, Docker >= 24, Compose >= 2.26.1, x86-only prebuilt images) | All three paths exist; no fixed unified minimum resource requirement, sizing is based on vector database, documents, models, and concurrency; Cloud is better suited to low-cost validation before migration to a private environment |
+
+Accept Skills by release status: RAGFlow Skills Space is on the main branch, so formal release boundary and availability date should enter the POC or contract. Stable documentation and released capabilities should be the basis for current selection.
+
+> **Acceptance condition**: For complex-document RAG, use the same documents, Embedding, ReRank, LLM, TopK, and hardware. Convert resource requirements into actual server cost based on enterprise data scale.
+
+### 2.3 Where RAGFlow Has an Advantage
+
+- **Product mindshare for complex layouts and scanned documents**: Deep document understanding, adjustable chunking, and scanned-document OCR are signature strengths. Acknowledge them directly and compare with the enterprise's own golden set.
+- **Multi-source incremental sync connectors**: Public release records list Confluence, S3, Notion, Discord, Google Drive, and more, which is more attractive to overseas collaboration stacks.
+- **Apache-2.0 license**: More permissive for secondary development, internal platformization, and avoiding proprietary cloud lock-in.
+- **Langfuse tracing semantics**: Public documentation clearly traces retrieval, ranking, generation, prompts, and responses, which fits teams already using Langfuse.
+
+When enterprise documents are mainly scanned contracts, scanned research reports, and complex tables, include RAGFlow in the final POC and record parsing quality, manual adjustment time, and subsequent application development time.
+
+---
+
+## 3. Licensing and Support: Versions and Delivery Responsibility
+
+| Item | RAGFlow | FastGPT |
+|---|---|---|
+| Product path | Cloud + Apache-2.0 self-hosting + Enterprise | Cloud + community self-hosting + managed / self-hosted commercial editions |
+| Open source license | Apache-2.0 | FastGPT Open Source License: allows commercial use as a backend service provider for other applications and as an application development platform delivered to enterprises; written authorization is required to operate a similar multi-tenant SaaS with the source code or to remove/modify the LOGO and copyright information in the console |
+| Public minimum self-hosted infrastructure | Minimum 4 cores / 16GB / 50GB; Docker >= 24; Compose >= 2.26.1; prebuilt images only support x86 | No fixed unified minimum CPU / memory, sizing is based on vector database, document volume, model, and concurrency |
+| Deployment method | Docker Compose + Helm | Docker Compose, with multiple vector backends supported; Kubernetes commercial delivery boundaries require confirmation |
+| Private / offline | Self-hosted; Enterprise provides BYOC / local deployment | Commercial editions support private deployment and fully offline operation |
+| Enterprise identity / governance | RBAC, OAuth2 / OIDC, team permissions; audit logs and configurable quotas require POC and contract confirmation | Commercial editions provide ABAC + RBAC, SSO, multi-tenancy, and an admin console; advanced cloud plans publicly list 720-day team operation logs |
+| Procurement model | Cloud free tier + two monthly subscriptions; Enterprise provides dedicated support and custom SLA, quote-based | Cloud has free and two monthly subscriptions; managed commercial edition starts monthly; private deployment uses per-server licenses in three versions |
+| Vendor support | Enterprise provides dedicated support and custom SLA, quote-based; the commit range for custom SLA should be confirmed in writing | Four support tiers, with coverage expanding from business days to 7x24 and first-response targets increasing by tier; all paid tiers include security patches, new feature support, and remote online assistance; private deployment delivery can include installation, debugging, and vendor technical maintenance |
+
+Apache-2.0 and the FastGPT Open Source License create different constraint profiles. Legal should review SaaS operation, de-branding, secondary development distribution, and private deployment item by item, then write the conclusion into the procurement checklist.
+
+Subscription or license, implementation, maintenance, model usage, infrastructure, and operations should enter the three-year TCO, with same-day written quotes from both sides.
+
+The procurement checklist should require both sides to provide a responsibility matrix, incident levels, recovery targets, upgrade/rollback owners, and support coverage. Record first-response targets separately from repair time limits. Final commitments should be based on the contract.
+
+---
+
+## 4. POC Validation: Run the Same Documents Twice
+
+For this product pair, the most valuable validation method is concrete: **ask both vendors to process the same complex documents and record four quantities.**
+
+| Record item | Why it must be recorded |
+|---|---|
+| **Parsing quality** | Table, heading, page number, and image fidelity, plus parsing success rate, with manual sampling for each file |
+| **RAG metrics** | Recall@K, MRR / NDCG, citation accuracy, hallucination rate, and no-answer refusal rate |
+| **Manual adjustment time** | When parsing is below usable quality, record how long it takes to make the result usable. This often affects delivery cycle more than parsing accuracy itself |
+| **Subsequent application development time** | After the knowledge base is usable, record how long it takes to turn it into a real application across Agents, scheduled tasks, channel publishing, and permissions |
+
+Manual adjustment time and subsequent application development time directly affect delivery cycle and total cost. The four records together form the selection conclusion.
+
+Use the unified POC measurement table to fix six metric categories and evidence artifacts:
+
+| Category | Required metrics | Unified conditions | Evidence artifact |
+|---|---|---|---|
+| RAG quality | Recall@K, MRR / NDCG, citation accuracy, hallucination rate, no-answer refusal rate | Same golden question set, Embedding, ReRank, LLM, TopK | Replayable test set + per-question results |
+| Complex documents | Table / heading / page number / image fidelity, parsing success rate, time and cost per 100 pages | Same scanned files, contracts, research reports, PPTX, XLSX | Diff between source and parsed result + manual sampling |
+| Online performance | P50 / P95 / P99 latency, success rate, requests per second, peak concurrency | Same model endpoint, vector database, machine type, data volume, and warm-up method | Load test script, raw report, resource curves |
+| Reliability | Node failure recovery, retry idempotency, queue backlog, upgrade rollback, backup recovery | Same fault-injection script and data scale | Incident timeline, lost/duplicate records, recovery time |
+| Security and governance | Privilege escalation, SSRF, secret leakage, sandbox escape, tenant isolation, audit coverage | Same threat cases and permission matrix | Case results, audit records, remediation items |
+| Three-year TCO | License, model, parsing / OCR, storage, database, operations, upgrades, and support | Unified three-year business growth assumptions | Three-year cash flow + person-days + risk reserve |
+
+Put the following metrics into the "not publicly listed / POC required / contract required" checklist: steady-state and peak concurrency, requests per second, token throughput per minute, parsing and retrieval latency under specified hardware, maximum application and knowledge-base counts, availability SLA and RTO / RPO, and real-time connector and plugin counts.
+
+---
+
+## 5. Selection Recommendations: Decide by Document Structure and Operations Needs
+
+| First success factor for the project | Recommendation |
+|---|---|
+| Scanned contracts, scanned research reports, complex tables, and layout parsing almost determine project success | **RAGFlow must enter the final POC**, using the enterprise's own golden set |
+| Knowledge sources are mainly in overseas collaboration stacks such as Confluence, S3, Notion, and Google Drive | RAGFlow's connector coverage is an immediate gain |
+| The team already uses Langfuse for tracing | RAGFlow's tracing semantics can be reused directly |
+| Strict license permissiveness is required for internal platformization or deep secondary development | Apache-2.0 gives broader boundaries, with legal still reviewing the LICENSE item by item |
+| Knowledge sources are mainly in Feishu, Yuque, and DingTalk, and continuous sync is required | FastGPT natively covers these Chinese knowledge sources and continuous website sync |
+| Daily scheduled automation is required, with results sent to enterprise IM | FastGPT's built-in scheduled automation and Chinese channel publishing are verifiable differences |
+| Admin audit logs and unified quotas are required for API Keys, share links, and QPM | FastGPT commercial editions and Cloud publicly expose this loop |
+| Post-launch operations require user feedback, session labeling, app evaluation, and dashboards | FastGPT's operations loop covers this chain |
+| Response coverage, recovery responsibility, and upgrade rollback must be written into the contract | Ask both sides for a responsibility matrix and service checklist. FastGPT's support tier structure is public; RAGFlow custom SLA requires quote confirmation |
+
+When document parsing and complete operations are both core constraints, run one parallel POC with both vendors: use the same golden documents for parsing, record person-days and implementation barriers during the application and operations stage, then combine the results into a total cost table.
+
+Parsing quality should be measured with the enterprise golden set under unified conditions. Uncovered capabilities should enter the POC checklist or vendor written confirmation.
+
+---
+
+> **Sources**: RAGFlow and FastGPT official websites, official documentation, official repositories, official pricing pages, and public release records
+> **Verification date**: 2026-07-20
+> **Versions and plans**: RAGFlow Cloud / Apache-2.0 self-hosting / Enterprise; FastGPT Cloud / community self-hosting / managed and self-hosted commercial editions. RAGFlow capabilities on the main branch that are not formally released are excluded
+> **Update record**: V1.2 (2026-08-08) rewrote visible copy while preserving facts on parsing, operations, support responsibility, and POC. Pricing, version numbers, connector and plugin counts, and Cloud quotas use a 90-day review cycle
+
+> **Update record addendum**: On 2026-08-08, page framing and body copy were unified around applicable scenarios, production differences, contract responsibility, and same-condition POC. Evidence remains stored in delivery metadata and the manifest.

--- a/content/competitors/en/self-build-vs-platform.md
+++ b/content/competitors/en/self-build-vs-platform.md
@@ -1,0 +1,159 @@
+<!--
+Delivery metadata (not published with body content)
+slug: self-build-vs-platform
+Meta title: Self-Build vs Platform: Three-Year Build-vs-Buy TCO
+Meta description: Compare self-build, open source, and platform options across labor, runtime, security, operations, upgrades, and support over three years. Keep TCO auditable.
+keywords: self-build cost, three-year TCO, platform engineering, vendor support, open source self-hosting
+Structured data: Article + BreadcrumbList (no FAQPage)
+Mapped semantic questions: 33, 35
+Demand basis: local GPT 108,899 (largest sitewide term family, 17% of total impressions); enterprise management knowledge base 5,304; common enterprise management systems 7,786 (real impressions from client Baidu Ads backend, 2026-01-01 to 2026-05-28)
+Sources: client KB 7.1.5 / 7.3.3 / 7.4.2 / 7.5-01 / 7.5-02 / 7.5-04 / 7.5-09 - 3.3 - 4.3 - 5.4 - 6.3; verified on 2026-07-20
+Internal links: 1. MaxKB procurement comparison 2. RAGFlow document-parsing comparison 3. Official pricing page
+Schedule: W3 first batch
+Sign-off: messaging review (does not block publishing) - Content is based on the client KB. Before publishing, ask the client to verify: 1. version and capability boundaries 2. commercial messaging 3. naming and wording. If anything is inaccurate, the client can skip this page or request corrections; no signature workflow is required.
+-->
+
+# Self-Build or Platform: Four Cost Buckets to Calculate
+
+**Self-building or running open source directly gives more room when a platform engineering team already exists and wants deep control. A platform solution fits teams that need fast launch, a mature runtime, an upgrade path, and support channels.**
+
+Technical teams can build a vector retrieval and Q&A prototype. Production adds parsing maintenance, training queues, workflow recovery, sandboxing, permissions, audit, evaluation, channels, and upgrades. These items determine long-term labor and delivery pace.
+
+**Use the same three-year requirements checklist to calculate self-build and platform options separately, including development, testing, security, operations, upgrades, and on-call person-days.** The cost conclusion should show cash flow, person-days, and risk reserve together.
+
+---
+
+## 1. Production Boundary: Long-Term Work Beyond the Prototype
+
+A self-built RAG prototype can run quickly: install a vector database, chunk documents, connect a model, and show a demo within days. In production, the work concentrates around the main chain:
+
+- A document changes layout, parsing fails, and nobody can tell which step broke.
+- The same document cannot be retrieved with a different phrasing because one body has only one index.
+- Dozens of documents fail in the training queue, and the only available fix is rerunning the whole knowledge base.
+- A workflow fails at step five, requiring breakpoint recovery and idempotent retry.
+- Someone asks where last month's calls spent money, and cost needs to be split by parsing, vectorization, retrieval, and generation.
+- The business team asks for Feishu and WeCom, and the channel adapter needs to be written from scratch.
+- Security review arrives and asks whether code execution nodes have a sandbox, external tools have SSRF protection, secrets are managed safely, and audit logs are retained long enough.
+
+Production quality depends on document quality, chunking method, update frequency, permission boundaries, retrieval configuration, and model capability. Each item needs a clear owner, regression set, and operations budget.
+
+---
+
+## 2. Cost Structure: Four Work Groups Plus Support Responsibility
+
+Long-term work for self-building or running open source directly falls into four groups. Platform procurement also requires a separate review of vendor support responsibility. List person-days and service scope by group so the three-year TCO is comparable.
+
+| Work group | Self-build / direct open source | Platform procurement | Validation method |
+|---|---|---|---|
+| Parsing, retrieval, and knowledge maintenance | Maintain multi-layout parsing, indexes, citations, and retraining queues in-house | Use the platform's existing knowledge-engineering chain and verify version boundaries | Same golden set and parsing-sample POC |
+| Agent and workflow runtime | Build failure recovery, human interaction, debugging, and evaluation in-house | Configure platform capabilities and verify interactive state and tool boundaries | Same workflow fault-injection and recovery test |
+| Security and governance | Own model adaptation, secrets, sandboxing, permissions, audit, and multi-tenancy | Verify governance capabilities and responsibility boundaries by version and contract | Same threat cases and permission matrix |
+| Publishing, operations, and support | Maintain channels, upgrades, backup, monitoring, on-call, and user support in-house | Verify channels, upgrade path, and support tiers by procurement model | Three-year TCO and launch rehearsal |
+
+### 2.1 Group One: Parsing, Retrieval, and Knowledge Maintenance
+
+Document parsing, chunking, indexing, retrieval, ReRank, citation tracing, and retraining queues.
+
+Production needs fallback parsing for multiple layouts, adjustable chunking, multiple indexes for one body, independent index editing, single-item training queue repair, retrieval history review, and citation location.
+
+### 2.2 Group Two: Agent and Workflow Runtime
+
+Agent / workflow runtime, failure recovery, human interaction, debugging, logs, and evaluation.
+
+The three key items are **failure recovery** (node retry idempotency and queue backlog), **human interaction** (pause, form confirmation, and in-place recovery), and **evaluation** (fixed question-set regression).
+
+### 2.3 Group Three: Security and Governance
+
+Model adaptation, tool security, secrets, SSRF, code sandboxing, authentication, RBAC, SSO, audit, and multi-tenancy.
+
+Security review and customer compliance will ask for model adaptation, tool security, secrets, SSRF, code sandboxing, authentication, RBAC, SSO, audit, and multi-tenancy. **Code sandboxing and tenant isolation** belong to runtime architecture and should be checked early in solution design.
+
+### 2.4 Group Four: Publishing, Operations, and Support
+
+Publishing channels, API compatibility, upgrade rollback, backup recovery, monitoring and alerts, on-call, and user support.
+
+An all-hands knowledge base needs on-call, alerts, backup recovery, and user support. Wrong answers, slow answers, and outages all need clear handlers and person-day budgets.
+
+Vendor support is the fifth cost variable. The self-build side carries it through team on-call, while the platform side defines it through support tiers and service checklists:
+
+| Item | Self-build / direct open source | Platform procurement |
+|---|---|---|
+| Coverage hours and first-response target | Internal on-call schedule and rotation | Divided by support tier, coverage can reach 7x24, and first-response targets increase by tier |
+| Security patches and version upgrades | Track upstream, upgrade, and rehearse rollback internally | Paid tiers include security patches and new-feature support; upgrade support scope follows the contract |
+| Fault location and recovery responsibility | Entirely on the internal team | Divided by responsibility matrix and written item by item in the service checklist |
+| Initial deployment and debugging | Internal team owns it | Delivery scope can include installation, debugging, and vendor technical maintenance |
+| Support channel | Community channels, with no response commitment | Tickets and dedicated support groups, with an account manager in the highest tier |
+
+Convert self-build on-call into person-days and put it into three-year TCO. On the platform side, write coverage hours, first-response targets, repair responsibility, and upgrade rollback into the service checklist. Record first-response targets separately from repair time limits. Final commitments should be based on the contract.
+
+### 2.5 Use Requirement Priority to Decide the Self-Build Boundary
+
+Mark each item as "required / optional / future": **required items** cover parsing, retrieval, basic permissions, and publishing channels; **optional items** include evaluation systems, cost split, and session labeling; **future items** include multi-tenancy, clustering, and cross-region disaster recovery.
+
+Internal knowledge bases with few required items, deferrable optional items, and clear future items are good candidates for self-build. When SSO, audit, multi-tenancy, and code sandboxing enter the required list together, the self-build scope expands into platform engineering. The requirement-priority table should become the direct input for the POC and both quotes.
+
+---
+
+## 3. Procurement Boundaries: Platform Fees and Migration Cost
+
+Orchestration, RAG, ReRank, external tools, and observability add length to the call chain. Platform options need latency, token, parsing, and storage costs included in acceptance.
+
+Choose one real business chain and compare direct model calls, self-built orchestration, and the platform option. Record end-to-end P95 / P99 latency, tokens, parsing and storage cost, failure rate, development person-days, and operations person-days.
+
+Platform options can choose models, storage, vector backends, APIs, and deployment methods according to enterprise requirements. Workflow configuration and commercial features create migration cost. The POC should record application and data export, model switching, vector-backend switching, backup recovery, and API compatibility results, then write the exit path into the procurement checklist.
+
+---
+
+## 4. POC Validation: Put Both Options Into the Same Quote
+
+### 4.1 Three-Year TCO Calculation Table
+
+| Cost layer | Self-build / direct open source | Platform procurement | Fill-in requirement |
+|---|---|---|---|
+| Infrastructure | Servers or GPUs, database, vector database, object storage, network | Same for self-hosted, included in subscription for cloud | Use three-year business growth assumptions, not current usage |
+| Model consumption | Vectorization + generation, estimated by real Q&A volume | Same | Use the same Q&A volume assumptions on both sides |
+| License / subscription | Open source license basis plus secondary development and distribution boundaries | Official pricing page price on the day | Procurement fills same-day real prices for both sides |
+| Parsing / OCR | Self-built or third-party calls | Same | The higher the complex-layout ratio, the larger this difference becomes |
+| Platform engineering labor | Person-days across the four platform engineering groups | Integration and configuration person-days | Include in three-year total person-days |
+| Security and operations | Sandbox, secrets, permissions, audit, multi-tenancy, monitoring | Partially included by version + customer-side operations | List by actual security review requirements |
+| Upgrades and on-call | Upgrade rollback, backup recovery, alert response, user support | Support tier + customer-side first line | Count over three years, not only year one |
+| Risk reserve | Key-person loss, rework, failed review | Version boundary mismatch, migration cost | Reserve on both sides |
+
+**The final output is three tables: three-year cash flow, person-days, and risk reserve**, plus sensitivity analysis for member count, document volume, and request volume.
+
+### 4.2 Six Required Test Categories
+
+| Category | Required metrics | Unified conditions |
+|---|---|---|
+| RAG quality | Recall@K, MRR / NDCG, citation accuracy, hallucination rate, no-answer refusal rate | Same golden question set, Embedding, ReRank, LLM, TopK |
+| Complex documents | Table / heading / page number / image fidelity, parsing success rate, time and cost per 100 pages | Same scanned files, contracts, research reports, PPTX, XLSX |
+| Online performance | P50 / P95 / P99 latency, success rate, requests per second, peak concurrency | Same model endpoint, vector database, machine type, data volume, and warm-up method |
+| Reliability | Node failure recovery, retry idempotency, queue backlog, upgrade rollback, backup recovery | Same fault-injection script and data scale |
+| Security and governance | Privilege escalation, SSRF, secret leakage, sandbox escape, tenant isolation, audit coverage | Same threat cases and permission matrix |
+| Three-year TCO | See 4.1 | Unified three-year business growth assumptions |
+
+Version stability, upgrade rollback, data recovery, concurrency, security, and support response should enter the production acceptance checklist, with upgrade rehearsals, backup recovery, long-running load tests, security cases, and fault injection scheduled separately.
+
+---
+
+## 5. Selection Recommendations: Decide by Team Capability and Pace
+
+| Project condition | Recommendation |
+|---|---|
+| The need is for small-team internal use, and the team can own deployment, upgrades, backup, and security | Community self-hosting or self-build can enter the candidate set, with procurement scope controlled by requirement priority |
+| The need is concentrated on vector retrieval + Q&A, covering basic permissions and a single publishing channel | The self-build boundary is clear and manageable for the team |
+| Requirements enter SSO, multi-tenancy, audit, long-retention logs, commercial support, or explicit SLA | These are long-term platform-engineering items, so include procurement options in the comparison |
+| Strict external sync + department information isolation + strong audit and cost management are all required | Write each item into the contract and acceptance checklist, then include platform options in the comparison |
+| The technical team can self-build, but headcount is already fully loaded | Calculate platform-engineering person-days alongside business person-days, and compare opportunity cost |
+| Business stakeholders require response coverage and recovery responsibility that can be written into a contract | Convert self-build on-call into person-days, and put platform support tiers plus responsibility matrix into the comparison |
+
+The self-build versus platform conclusion should be based on cost, person-days, delivery time, and risk reserve under the same three-year requirements checklist.
+
+---
+
+> **Sources**: Public product materials verified for the project and general engineering practice; the cost checklist comes from section 7.1.5 of the client product knowledge base, and the POC measurement table comes from section 7.3.3
+> **Verification date**: 2026-07-20
+> **Versions and plans**: References to FastGPT use the current public version boundaries for community self-hosting, Cloud, and commercial editions
+> **Update record**: V1.2 (2026-08-08) rewrote visible copy while preserving facts on cost, support responsibility, and POC. Pricing and version boundaries use a 90-day review cycle
+
+> **Update record addendum**: On 2026-08-08, page framing and body copy were unified around applicable scenarios, long-term cost, contract responsibility, and same-condition POC. Evidence remains stored in delivery metadata and the manifest.

--- a/nginx.conf
+++ b/nginx.conf
@@ -22,6 +22,7 @@ server {
       rewrite ^/zh/price/?$ https://fastgpt.cn/price permanent;
       rewrite ^/zh/faq/?$ https://fastgpt.cn/faq permanent;
       rewrite ^/zh/faq/(.+?)/?$ https://fastgpt.cn/faq/$1 permanent;
+      rewrite ^/zh/compare/?$ https://fastgpt.cn/compare permanent;
       rewrite ^/zh/compare/(.+?)/?$ https://fastgpt.cn/compare/$1 permanent;
       rewrite ^/(en|zh-hant|ja|ar|vi|th|id|ms)/?$ https://fastgpt.io/$1 permanent;
       rewrite ^/(en|zh-hant|ja|ar|vi|th|id|ms)/(.+?)/?$ https://fastgpt.io/$1/$2 permanent;
@@ -34,6 +35,7 @@ server {
       rewrite ^/zh/price/?$ https://fastgpt.cn/price permanent;
       rewrite ^/zh/faq/?$ https://fastgpt.cn/faq permanent;
       rewrite ^/zh/faq/(.+?)/?$ https://fastgpt.cn/faq/$1 permanent;
+      rewrite ^/zh/compare/?$ https://fastgpt.cn/compare permanent;
       rewrite ^/zh/compare/(.+?)/?$ https://fastgpt.cn/compare/$1 permanent;
       rewrite ^/zh/(.+?)/?$ https://fastgpt.cn/zh/$1 permanent;
       rewrite ^/en/?$ https://fastgpt.io/ permanent;

--- a/public/_redirects
+++ b/public/_redirects
@@ -6,6 +6,8 @@
 /zh/faq/* https://fastgpt.cn/faq/:splat 301
 /zh/faq/ https://fastgpt.cn/faq 301
 /zh/faq https://fastgpt.cn/faq 301
+/zh/compare/ https://fastgpt.cn/compare 301
+/zh/compare https://fastgpt.cn/compare 301
 /zh/compare/*/ https://fastgpt.cn/compare/:splat 301
 /zh/compare/* https://fastgpt.cn/compare/:splat 301
 /zh/ https://fastgpt.cn/ 301

--- a/scripts/verify-i18n-seo.js
+++ b/scripts/verify-i18n-seo.js
@@ -12,6 +12,12 @@ const baseUrls = {
 };
 const baseUrl = baseUrls[variant];
 const faqId = 'Why-are-enterprises-paying-more';
+const compareSlugs = [
+  'dify-vs-fastgpt',
+  'ragflow-vs-fastgpt',
+  'maxkb-vs-fastgpt',
+  'self-build-vs-platform'
+];
 const localePaths = {
   en: '',
   'zh-CN': '',
@@ -46,6 +52,15 @@ function getAttribute(tag, attribute) {
   return tag.match(new RegExp(`\\s${attribute}="([^"]*)"`, 'i'))?.[1];
 }
 
+function getTitle(html) {
+  return html.match(/<title>([^<]+)<\/title>/i)?.[1] || '';
+}
+
+function getMetaDescription(html) {
+  const meta = getTags(html, 'meta').find((tag) => getAttribute(tag, 'name') === 'description');
+  return getAttribute(meta || '', 'content') || '';
+}
+
 function getCanonical(html, route) {
   const tag = getTags(html, 'link').find(
     (candidate) => getAttribute(candidate, 'rel') === 'canonical'
@@ -65,7 +80,7 @@ function getAlternates(html) {
 
 function expectedLocaleUrl(language, pathSuffix) {
   const suffix = pathSuffix || '';
-  if (language === 'zh-CN') return `${baseUrls.cn}${suffix}`;
+  if (language === 'zh' || language === 'zh-CN') return `${baseUrls.cn}${suffix}`;
   if (language === 'en') return `${baseUrls.io}${suffix}`;
   return `${baseUrls.io}${localePaths[language]}${suffix}`;
 }
@@ -148,6 +163,40 @@ function verifySitemap() {
   assert(urls.includes(`${baseUrl}/price`), 'Sitemap is missing the canonical pricing URL');
   assert(urls.includes(`${baseUrl}/faq`), 'Sitemap is missing the canonical FAQ URL');
   assert(urls.includes(`${baseUrl}/faq/${faqId}`), 'Sitemap is missing a canonical FAQ detail URL');
+  assert(urls.includes(`${baseUrl}/compare`), 'Sitemap is missing the canonical compare hub URL');
+  for (const slug of compareSlugs) {
+    assert(
+      urls.includes(`${baseUrl}/compare/${slug}`),
+      `Sitemap is missing the canonical compare URL for ${slug}`
+    );
+  }
+}
+
+function verifyCompareMetadataLengths() {
+  if (variant !== 'io') return;
+
+  const routes = ['/compare', ...compareSlugs.map((slug) => `/compare/${slug}`)];
+  for (const route of routes) {
+    const html = resolveHtml(route);
+    const title = getTitle(html);
+    const description = getMetaDescription(html);
+    assert(
+      title.length >= 50 && title.length <= 60,
+      `Title for ${route} is outside the target range: ${title.length}`
+    );
+    assert(
+      description.length >= 150 && description.length <= 160,
+      `Description for ${route} is outside the target range: ${description.length}`
+    );
+  }
+}
+
+function verifyComparePages() {
+  const compareLanguages = ['en', 'zh', 'zh-CN'];
+  verifyPage('/compare', '/compare', compareLanguages);
+  for (const slug of compareSlugs) {
+    verifyPage(`/compare/${slug}`, `/compare/${slug}`, compareLanguages);
+  }
 }
 
 function main() {
@@ -160,6 +209,8 @@ function main() {
   verifyPage('/price', '/price', pageLanguages);
   verifyPage('/faq', '/faq', faqLanguages);
   verifyPage(`/faq/${faqId}`, `/faq/${faqId}`, faqLanguages);
+  verifyComparePages();
+  verifyCompareMetadataLengths();
   verifySitemap();
 
   console.log(`i18n SEO verification passed for ${variant} (${baseUrl})`);

--- a/src/app/[lang]/compare/[slug]/page.tsx
+++ b/src/app/[lang]/compare/[slug]/page.tsx
@@ -1,13 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import HomeThemeFix from '@/components/home/HomeThemeFix';
-import Navbar from '@/components/home/Navbar';
-import { ArticleJsonLd, BreadcrumbJsonLd } from '@/components/JsonLd';
-import ComparisonPage from '@/components/compare/ComparisonPage';
-import { comparisonSlugs, getComparisonPage } from '@/content/competitor';
-import { getDictionary } from '@/lib/i18n';
-import { getCompareAlternates, getCompareCanonicalUrl } from '@/lib/seo';
-import { getDefaultLocalePath } from '@/lib/localizedRoutes';
+import { ComparisonRoute, getComparisonMetadata } from '@/components/compare/ComparisonRoute';
+import { comparisonSlugs } from '@/content/competitor';
 
 export default async function CompetitorComparisonPage({
   params
@@ -17,36 +11,7 @@ export default async function CompetitorComparisonPage({
   const { lang, slug } = await params;
   const langName = lang || 'zh';
   if (langName !== 'zh') notFound();
-  const page = getComparisonPage(slug);
-  if (!page) notFound();
-  const dict = await getDictionary('zh');
-  const canonical = getCompareCanonicalUrl(page.slug);
-  const siteBaseUrl = (process.env.NEXT_PUBLIC_HOME_URL || 'https://fastgpt.io').replace(/\/$/, '');
-
-  return (
-    <div className="home overflow-x-hidden comparison-page-shell">
-      <BreadcrumbJsonLd
-        items={[
-          { name: dict.JsonLd.breadcrumbHome, url: `${siteBaseUrl}${getDefaultLocalePath('zh')}` },
-          { name: page.title, url: canonical }
-        ]}
-      />
-      <ArticleJsonLd
-        headline={page.title}
-        description={page.description}
-        image={`https://fastgpt.cn${page.asset.path}`}
-        url={canonical}
-        inLanguage="zh-CN"
-        datePublished={page.status === 'published' ? page.dates.datePublished : undefined}
-        dateModified={page.dates.dateModified}
-      />
-      <HomeThemeFix />
-      <Navbar links={dict.links} t={dict.Home.navCta} variant="comparison" />
-      <main className="comparison-page">
-        <ComparisonPage page={page} homeLabel="返回内容中心" />
-      </main>
-    </div>
-  );
+  return <ComparisonRoute locale="zh" slug={slug} />;
 }
 
 export async function generateStaticParams() {
@@ -62,33 +27,8 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { lang, slug } = await params;
   const langName = lang || 'zh';
-  const page = getComparisonPage(slug);
-  if (!page || langName !== 'zh') {
+  if (langName !== 'zh') {
     return { title: 'Comparison page not found', robots: { index: false, follow: false } };
   }
-  const canonical = getCompareCanonicalUrl(page.slug);
-  const image = `https://fastgpt.cn${page.asset.path}`;
-  return {
-    title: page.title,
-    description: page.description,
-    keywords: page.keywords,
-    alternates: getCompareAlternates(page.slug),
-    robots: page.status === 'published' ? { index: true, follow: true } : { index: false, follow: false },
-    openGraph: {
-      title: page.title,
-      description: page.description,
-      type: 'article',
-      url: canonical,
-      locale: 'zh_CN',
-      publishedTime: page.status === 'published' ? page.dates.datePublished : undefined,
-      modifiedTime: page.dates.dateModified,
-      images: [{ url: image, width: page.asset.width, height: page.asset.height, alt: page.asset.alt }]
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: page.title,
-      description: page.description,
-      images: [image]
-    }
-  };
+  return getComparisonMetadata('zh', slug, { indexable: false });
 }

--- a/src/app/[lang]/compare/page.tsx
+++ b/src/app/[lang]/compare/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { ComparisonHubRoute, getComparisonHubMetadata } from '@/components/compare/ComparisonHubRoute';
+
+export default async function CompareHubLocalizedPage({
+  params
+}: {
+  params: Promise<{ lang?: string }>;
+}) {
+  const { lang } = await params;
+  if ((lang || 'zh') !== 'zh') notFound();
+  return <ComparisonHubRoute locale="zh" />;
+}
+
+export async function generateStaticParams() {
+  return [{ lang: 'zh' }];
+}
+
+export const dynamicParams = false;
+
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ lang?: string }>;
+}): Promise<Metadata> {
+  const { lang } = await params;
+  if ((lang || 'zh') !== 'zh') {
+    return { title: 'Comparison hub not found', robots: { index: false, follow: false } };
+  }
+  return getComparisonHubMetadata('zh', { indexable: false });
+}

--- a/src/app/compare/[slug]/page.tsx
+++ b/src/app/compare/[slug]/page.tsx
@@ -1,7 +1,28 @@
-import { comparisonSlugs } from '@/content/competitor';
+import type { Metadata } from 'next';
+import { ComparisonRoute, getComparisonMetadata } from '@/components/compare/ComparisonRoute';
+import { comparisonSlugs, resolveCompareLocale } from '@/content/competitor';
+import { defaultLocale } from '@/lib/i18n';
 
-export { default, generateMetadata } from '@/app/[lang]/compare/[slug]/page';
+export default async function CompetitorComparisonPage({
+  params
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  return <ComparisonRoute locale={resolveCompareLocale(defaultLocale)} slug={slug} />;
+}
 
 export function generateStaticParams() {
   return comparisonSlugs.map((slug) => ({ slug }));
+}
+
+export const dynamicParams = false;
+
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  return getComparisonMetadata(resolveCompareLocale(defaultLocale), slug);
 }

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+import { ComparisonHubRoute, getComparisonHubMetadata } from '@/components/compare/ComparisonHubRoute';
+import { resolveCompareLocale } from '@/content/competitor';
+import { defaultLocale } from '@/lib/i18n';
+
+export default async function CompareHubPage() {
+  return <ComparisonHubRoute locale={resolveCompareLocale(defaultLocale)} />;
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  return getComparisonHubMetadata(resolveCompareLocale(defaultLocale));
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,8 +8,8 @@ import {
 } from '@/lib/siteRouting';
 import { TECH_ENTRIES } from '@/components/tech-center/data';
 import { getTechArticleLastModified, getTechCenterLastModified } from '@/lib/tech-center-content';
-import { getCompareCanonicalUrl } from '@/lib/seo';
-import { comparisonPages } from '@/content/competitor';
+import { getCompareCanonicalUrl, getCompareHubCanonicalUrl } from '@/lib/seo';
+import { getComparisonPagesForLocale } from '@/content/competitor';
 
 export const dynamic = 'force-static';
 
@@ -51,10 +51,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
     for (const article of TECH_ENTRIES) {
       addEntry(getOwnedLocaleUrl('zh', article.slug), getTechArticleLastModified(article));
     }
-    for (const page of Object.values(comparisonPages)) {
-      if (page.status !== 'published') continue;
-      addEntry(getCompareCanonicalUrl(page.slug), new Date(page.dates.dateModified));
-    }
+  }
+
+  const compareLocale = currentSiteVariant === 'cn' ? 'zh' : 'en';
+  addEntry(getCompareHubCanonicalUrl(compareLocale), now);
+  for (const page of getComparisonPagesForLocale(compareLocale)) {
+    if (page.status !== 'published') continue;
+    addEntry(getCompareCanonicalUrl(compareLocale, page.slug), new Date(page.dates.dateModified));
   }
 
   return entries;

--- a/src/components/compare/ComparisonHubPage.tsx
+++ b/src/components/compare/ComparisonHubPage.tsx
@@ -1,0 +1,92 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import type { CompareLocale } from '@/content/competitor';
+import { getComparisonPagesForLocale } from '@/content/competitor';
+import { getDefaultLocalePath } from '@/lib/localizedRoutes';
+import { getComparisonHubCopy } from './comparisonHubCopy';
+
+function getHubPageHref(locale: CompareLocale, slug: string) {
+  return getDefaultLocalePath(locale, `/compare/${slug}`);
+}
+
+function getHubImagePath(slug: string) {
+  return `/images/compare/${slug}.svg`;
+}
+
+export default function ComparisonHubPage({ locale }: { locale: CompareLocale }) {
+  const copy = getComparisonHubCopy(locale);
+  const pages = getComparisonPagesForLocale(locale);
+  const featuredPages = ['dify-vs-fastgpt', 'ragflow-vs-fastgpt']
+    .map((slug) => pages.find((page) => page.slug === slug))
+    .filter((page): page is (typeof pages)[number] => Boolean(page));
+
+  return (
+    <div className="comparison-hub-inner">
+      <div className="comparison-hub-topline">
+        <span className="comparison-hub-topline-code">FASTGPT / COMPARE</span>
+        <span>{copy.pageCountLabel}</span>
+      </div>
+
+      <header className="comparison-hub-hero">
+        <p className="comparison-eyebrow">
+          <span className="comparison-eyebrow-mark" aria-hidden="true" />
+          <span>{copy.heroEyebrow}</span>
+        </p>
+        <div className="comparison-hub-hero-grid">
+          <div className="comparison-hub-hero-copy">
+            <h1>{copy.heroTitle}</h1>
+            <p>{copy.heroDescription}</p>
+            <div className="comparison-hub-trust-strip" aria-label={copy.trustStripAriaLabel}>
+              <span>{locale === 'zh' ? '基于官方公开资料' : 'Based on official public sources'}</span>
+              <span>{locale === 'zh' ? '按同条件 POC 验收' : 'Validated through same-condition POC'}</span>
+              <span>{locale === 'zh' ? '持续同步 canonical' : 'Canonical and hreflang aligned'}</span>
+            </div>
+          </div>
+          <div className="comparison-hub-feature">
+            <span className="comparison-section-kicker">{copy.compareLabel}</span>
+            <h2>{copy.relatedTitle}</h2>
+            <p>{copy.relatedDescription}</p>
+            <div className="comparison-hub-mini-grid">
+              {featuredPages.map((page) => (
+                <Link href={getHubPageHref(locale, page.slug)} key={page.slug} className="comparison-hub-mini-card">
+                  <span>{page.title}</span>
+                  <ArrowRight aria-hidden="true" size={16} />
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section className="comparison-hub-grid" aria-label={copy.compareLabel}>
+        {pages.map((page, index) => (
+          <Link
+            href={getHubPageHref(locale, page.slug)}
+            className="comparison-hub-card"
+            key={page.slug}
+          >
+            <div className="comparison-hub-card-head">
+              <span className="comparison-hub-card-index">{String(index + 1).padStart(2, '0')}</span>
+              <span>{copy.cardPrefix}</span>
+            </div>
+            <Image
+              src={getHubImagePath(page.slug)}
+              alt={page.asset.alt}
+              width={page.asset.width}
+              height={page.asset.height}
+            />
+            <div className="comparison-hub-card-copy">
+              <h2>{page.title}</h2>
+              <p>{page.description}</p>
+              <span className="comparison-hub-card-cta">
+                {copy.cardCta}
+                <ArrowRight aria-hidden="true" size={15} />
+              </span>
+            </div>
+          </Link>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/src/components/compare/ComparisonHubRoute.tsx
+++ b/src/components/compare/ComparisonHubRoute.tsx
@@ -1,0 +1,125 @@
+import type { Metadata } from 'next';
+import { BreadcrumbJsonLd, JsonLdScript } from '@/components/JsonLd';
+import Footer from '@/components/home/Footer';
+import HomeThemeFix from '@/components/home/HomeThemeFix';
+import Navbar from '@/components/home/Navbar';
+import { getComparisonPagesForLocale, type CompareLocale } from '@/content/competitor';
+import { getDictionary } from '@/lib/i18n';
+import { localeMap } from '@/lib/locales';
+import {
+  getCompareHubAlternates,
+  getCompareHubCanonicalUrl
+} from '@/lib/seo';
+import { getOwnedLocaleUrl } from '@/lib/siteRouting';
+import ComparisonHubPage from './ComparisonHubPage';
+
+const hubLanguage: Record<CompareLocale, string> = {
+  en: 'en-US',
+  zh: 'zh-CN'
+};
+
+export async function ComparisonHubRoute({ locale }: { locale: CompareLocale }) {
+  const dict = await getDictionary(locale);
+  const canonical = getCompareHubCanonicalUrl(locale);
+
+  return (
+    <div className="home overflow-x-hidden comparison-page-shell">
+      <BreadcrumbJsonLd
+        items={[
+          { name: dict.JsonLd.breadcrumbHome, url: getOwnedLocaleUrl(locale) },
+          { name: locale === 'zh' ? '竞品对比' : 'Compare', url: canonical }
+        ]}
+      />
+      <JsonLdScript
+        data={{
+          '@context': 'https://schema.org',
+          '@graph': [
+            {
+              '@type': 'ItemList',
+              '@id': `${canonical}#item-list`,
+              itemListElement: getComparisonPagesForLocale(locale).map((page, index) => ({
+                '@type': 'ListItem',
+                position: index + 1,
+                name: page.title,
+                url: getOwnedLocaleUrl(locale, `/compare/${page.slug}`)
+              }))
+            },
+            {
+              '@type': 'CollectionPage',
+              '@id': `${canonical}#webpage`,
+              url: canonical,
+              name: locale === 'zh' ? 'FastGPT 竞品对比' : 'FastGPT Comparison Hub',
+              description:
+                locale === 'zh'
+                  ? '汇总 FastGPT 与 Dify、RAGFlow、MaxKB 及自研方案的对比页，按插件生态、复杂文档、采购可预测性、支持边界和三年 TCO 进入细页核对。'
+                  : 'Browse FastGPT with Dify, RAGFlow, MaxKB, and build-vs-buy pages from one indexable hub. Jump into fit, POC, support, and TCO checks you need for each route.',
+              inLanguage: hubLanguage[locale],
+              isPartOf: {
+                '@type': 'WebSite',
+                name: dict.JsonLd.siteName,
+                url: new URL(canonical).origin
+              }
+            }
+          ]
+        }}
+      />
+      <HomeThemeFix />
+      <Navbar links={dict.links} t={dict.Home.navCta} locale={locale} variant="comparison" />
+      <main className="comparison-page">
+        <ComparisonHubPage locale={locale} />
+      </main>
+      <div className="comparison-footer">
+        <Footer t={dict.Home.footer} />
+      </div>
+    </div>
+  );
+}
+
+export function getComparisonHubMetadata(
+  locale: CompareLocale,
+  { indexable = true }: { indexable?: boolean } = {}
+): Metadata {
+  const canonical = getCompareHubCanonicalUrl(locale);
+  const coverPage = getComparisonPagesForLocale(locale)[0];
+  const coverImage = coverPage ? getOwnedLocaleUrl(locale, coverPage.asset.path) : undefined;
+  const shouldIndex = indexable;
+
+  const title =
+    locale === 'zh'
+      ? 'FastGPT 竞品对比：Dify、RAGFlow、MaxKB'
+      : 'FastGPT Comparison Hub: Dify, RAGFlow, MaxKB, Build vs Buy';
+  const description =
+    locale === 'zh'
+      ? '汇总 FastGPT 与 Dify、RAGFlow、MaxKB 及自研方案的对比页，按插件生态、复杂文档、采购可预测性、支持边界和三年 TCO 进入细页核对。'
+      : 'Browse FastGPT with Dify, RAGFlow, MaxKB, and build-vs-buy pages from one indexable hub. Jump into fit, POC, support, and TCO checks you need for each route.';
+
+  return {
+    title,
+    description,
+    alternates: getCompareHubAlternates(locale),
+    robots: shouldIndex ? { index: true, follow: true } : { index: false, follow: false },
+    openGraph: {
+      title,
+      description,
+      type: 'website',
+      url: canonical,
+      locale: localeMap[locale] || 'en_US',
+      images: coverImage
+        ? [
+            {
+              url: coverImage,
+              width: 1200,
+              height: 630,
+              alt: coverPage?.asset.alt || title
+            }
+          ]
+        : undefined
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: coverImage ? [coverImage] : undefined
+    }
+  };
+}

--- a/src/components/compare/ComparisonPage.tsx
+++ b/src/components/compare/ComparisonPage.tsx
@@ -4,6 +4,7 @@ import { ArrowDownRight, ArrowLeft, ArrowRight, ExternalLink } from 'lucide-reac
 import type { ComparisonPage as ComparisonPageData, MarkdownBlock } from '@/content/competitor';
 import { getDefaultLocalePath, getFaqPath } from '@/lib/localizedRoutes';
 import ComparisonTables from './ComparisonTables';
+import { getComparisonCopy } from './comparisonCopy';
 
 function getInternalLinkHref(target: string, locale: string) {
   const path = locale === 'zh' && target.startsWith('/zh/') ? target.slice('/zh'.length) : target;
@@ -15,10 +16,10 @@ function sectionAnchorId(index: number) {
 }
 
 function sectionNavLabel(title: string) {
-  return title.replace(/^\d+\.\s*/, '').split('：')[0] || title;
+  return title.replace(/^\d+\.\s*/, '').split(/[:：]/)[0] || title;
 }
 
-function renderBlock(block: MarkdownBlock, key: string) {
+function renderBlock(block: MarkdownBlock, key: string, locale: ComparisonPageData['lang']) {
   if (block.type === 'paragraph') return <p key={key}>{block.text}</p>;
   if (block.type === 'quote') return <blockquote key={key}>{block.text}</blockquote>;
   if (block.type === 'list') {
@@ -28,7 +29,7 @@ function renderBlock(block: MarkdownBlock, key: string) {
     const Heading = block.level === 3 ? 'h3' : 'h4';
     return <Heading key={key}>{block.text}</Heading>;
   }
-  if (block.type === 'table' && block.table) return <ComparisonTables key={key} table={block.table} />;
+  if (block.type === 'table' && block.table) return <ComparisonTables key={key} table={block.table} locale={locale} />;
   return null;
 }
 
@@ -41,19 +42,22 @@ function PageImage({ page }: { page: ComparisonPageData }) {
   );
 }
 
-export default function ComparisonPage({ page, homeLabel }: { page: ComparisonPageData; homeLabel: string }) {
+export default function ComparisonPage({ page }: { page: ComparisonPageData }) {
+  const copy = getComparisonCopy(page.lang);
+  const pageCopy = page.ctaCopy || {};
+
   return (
     <>
       {page.status === 'preview' && (
         <div className="comparison-preview-banner" role="status">
-          内容预览 · 页面状态待确认
+          {copy.previewBanner}
         </div>
       )}
       <div className="comparison-page-inner">
         <div className="comparison-topline">
-          <Link href={getFaqPath('zh')} className="comparison-back-link">
+          <Link href={getFaqPath(page.lang)} className="comparison-back-link">
             <ArrowLeft aria-hidden="true" size={15} />
-            <span>{homeLabel}</span>
+            <span>{copy.backLabel}</span>
           </Link>
           <span className="comparison-topline-code">FASTGPT / COMPARE</span>
         </div>
@@ -62,13 +66,13 @@ export default function ComparisonPage({ page, homeLabel }: { page: ComparisonPa
           <div className="comparison-hero-copy">
             <p className="comparison-eyebrow">
               <span className="comparison-eyebrow-mark" aria-hidden="true" />
-              <span>FastGPT 选型指南</span>
+              <span>{copy.heroEyebrow}</span>
             </p>
             <h1>{page.title}</h1>
             <p className="comparison-dek">{page.heroSummary}</p>
             <div className="comparison-hero-actions">
               <a className="comparison-button comparison-button-primary" href={`#${sectionAnchorId(1)}`}>
-                <span>查看能力矩阵</span>
+                <span>{pageCopy.primaryHeroCta || copy.primaryHeroCta}</span>
                 <ArrowDownRight aria-hidden="true" size={16} />
               </a>
               <a
@@ -77,14 +81,21 @@ export default function ComparisonPage({ page, homeLabel }: { page: ComparisonPa
                 target="_blank"
                 rel="noreferrer"
               >
-                <span>打开官方资料</span>
+                <span>{pageCopy.secondaryHeroCta || copy.secondaryHeroCta}</span>
                 <ExternalLink aria-hidden="true" size={15} />
               </a>
             </div>
+            {!!page.trustSignals?.length && (
+              <div className="comparison-trust-strip" aria-label={copy.trustStripAriaLabel}>
+                {page.trustSignals.map((signal) => (
+                  <span key={signal}>{signal}</span>
+                ))}
+              </div>
+            )}
           </div>
           <div className="comparison-hero-side">
             <div className="comparison-hero-side-head">
-              <span>选型速览</span>
+              <span>{copy.heroSideLabel}</span>
               <span>01—{String(page.sections.length).padStart(2, '0')}</span>
             </div>
             <div className="comparison-hero-highlights">
@@ -99,8 +110,8 @@ export default function ComparisonPage({ page, homeLabel }: { page: ComparisonPa
           </div>
         </header>
 
-        <nav className="comparison-toc" aria-label="页面章节导航">
-          <span className="comparison-toc-label">比较维度</span>
+        <nav className="comparison-toc" aria-label={copy.tocAriaLabel}>
+          <span className="comparison-toc-label">{copy.tocLabel}</span>
           {page.sections.map((section, index) => (
             <a href={`#${sectionAnchorId(index)}`} key={section.id}>
               <span>{String(index + 1).padStart(2, '0')}</span>
@@ -111,11 +122,24 @@ export default function ComparisonPage({ page, homeLabel }: { page: ComparisonPa
 
         <div className="comparison-intro-grid">
           <aside className="comparison-intro-lead">
-            <span className="comparison-section-kicker">核心判断</span>
-            <h3>按项目约束做选择</h3>
+            <span className="comparison-section-kicker">{copy.coreKicker}</span>
+            <h3>{copy.coreTitle}</h3>
           </aside>
           <div className="comparison-intro">
-            {page.intro.map((block, index) => renderBlock(block, `intro-${index}`))}
+            {page.intro.map((block, index) => renderBlock(block, `intro-${index}`, page.lang))}
+            {!!page.contextualLinks?.length && (
+              <nav className="comparison-context-links" aria-label={copy.contextLinksAriaLabel}>
+                <span>{copy.contextLinksLabel}</span>
+                <div>
+                  {page.contextualLinks.map((link) => (
+                    <a href={getInternalLinkHref(link.target, link.locale)} key={`${link.target}-${link.label}`}>
+                      {link.label}
+                      <ArrowRight aria-hidden="true" size={14} />
+                    </a>
+                  ))}
+                </div>
+              </nav>
+            )}
           </div>
         </div>
 
@@ -128,7 +152,7 @@ export default function ComparisonPage({ page, homeLabel }: { page: ComparisonPa
                 <h2>{section.title}</h2>
               </div>
               <div className="comparison-section-content">
-                {section.blocks.map((block, blockIndex) => renderBlock(block, `${section.id}-${blockIndex}`))}
+                {section.blocks.map((block, blockIndex) => renderBlock(block, `${section.id}-${blockIndex}`, page.lang))}
               </div>
             </section>
           ))}
@@ -136,11 +160,11 @@ export default function ComparisonPage({ page, homeLabel }: { page: ComparisonPa
 
         <section className="comparison-link-panel" aria-labelledby="comparison-next-step">
           <div className="comparison-link-lead">
-            <span className="comparison-section-kicker">继续核对</span>
-            <h3 id="comparison-next-step">查看部署与采购细节</h3>
+            <span className="comparison-section-kicker">{copy.nextStepKicker}</span>
+            <h3 id="comparison-next-step">{pageCopy.nextStepTitle || copy.nextStepTitle}</h3>
           </div>
           <div className="comparison-link-content">
-            <p>从私有化、许可和 POC 清单继续核对落地条件。</p>
+            <p>{pageCopy.nextStepDescription || copy.nextStepDescription}</p>
             <div className="comparison-link-grid">
               {page.internalLinks.map((link) => (
                 <a href={getInternalLinkHref(link.target, link.locale)} key={`${link.target}-${link.label}`}>
@@ -152,18 +176,18 @@ export default function ComparisonPage({ page, homeLabel }: { page: ComparisonPa
           </div>
         </section>
 
-        <section className="comparison-cta" aria-label="继续核验">
+        <section className="comparison-cta" aria-label={copy.ctaAriaLabel}>
           <div>
-            <span className="comparison-section-kicker">FastGPT / compare</span>
-            <h3>把关键指标写进验收表</h3>
+            <span className="comparison-section-kicker">{copy.ctaKicker}</span>
+            <h3>{pageCopy.ctaTitle || copy.ctaTitle}</h3>
           </div>
           <div className="comparison-cta-actions">
             <a className="comparison-button comparison-button-primary" href={`#${sectionAnchorId(3)}`}>
-              <span>设计同条件 POC</span>
+              <span>{pageCopy.ctaButton || copy.ctaButton}</span>
               <ArrowRight aria-hidden="true" size={16} />
             </a>
             <a className="comparison-cta-text-link" href={page.officialSource} target="_blank" rel="noreferrer">
-              官方资料入口
+              {copy.officialSourceLink}
               <ExternalLink aria-hidden="true" size={14} />
             </a>
           </div>

--- a/src/components/compare/ComparisonRoute.tsx
+++ b/src/components/compare/ComparisonRoute.tsx
@@ -1,0 +1,94 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { ArticleJsonLd, BreadcrumbJsonLd } from '@/components/JsonLd';
+import Footer from '@/components/home/Footer';
+import HomeThemeFix from '@/components/home/HomeThemeFix';
+import Navbar from '@/components/home/Navbar';
+import ComparisonPage from '@/components/compare/ComparisonPage';
+import type { CompareLocale } from '@/content/competitor';
+import { getComparisonPage } from '@/content/competitor';
+import { getDictionary } from '@/lib/i18n';
+import { localeMap } from '@/lib/locales';
+import { getCompareAlternates, getCompareCanonicalUrl } from '@/lib/seo';
+import { getOwnedLocaleUrl } from '@/lib/siteRouting';
+
+const articleLanguage: Record<CompareLocale, string> = {
+  en: 'en-US',
+  zh: 'zh-CN'
+};
+
+export async function ComparisonRoute({ locale, slug }: { locale: CompareLocale; slug: string }) {
+  const page = getComparisonPage(slug, locale);
+  if (!page) notFound();
+
+  const dict = await getDictionary(locale);
+  const canonical = getCompareCanonicalUrl(locale, page.slug);
+  const image = getOwnedLocaleUrl(locale, page.asset.path);
+
+  return (
+    <div className="home overflow-x-hidden comparison-page-shell">
+      <BreadcrumbJsonLd
+        items={[
+          { name: dict.JsonLd.breadcrumbHome, url: getOwnedLocaleUrl(locale) },
+          { name: page.title, url: canonical }
+        ]}
+      />
+      <ArticleJsonLd
+        headline={page.title}
+        description={page.description}
+        image={image}
+        url={canonical}
+        inLanguage={articleLanguage[locale]}
+        datePublished={page.status === 'published' ? page.dates.datePublished : undefined}
+        dateModified={page.dates.dateModified}
+      />
+      <HomeThemeFix />
+      <Navbar links={dict.links} t={dict.Home.navCta} locale={locale} variant="comparison" />
+      <main className="comparison-page">
+        <ComparisonPage page={page} />
+      </main>
+      <div className="comparison-footer">
+        <Footer t={dict.Home.footer} />
+      </div>
+    </div>
+  );
+}
+
+export function getComparisonMetadata(
+  locale: CompareLocale,
+  slug: string,
+  { indexable = true }: { indexable?: boolean } = {}
+): Metadata {
+  const page = getComparisonPage(slug, locale);
+  if (!page) {
+    return { title: 'Comparison page not found', robots: { index: false, follow: false } };
+  }
+
+  const canonical = getCompareCanonicalUrl(locale, page.slug);
+  const image = getOwnedLocaleUrl(locale, page.asset.path);
+  const shouldIndex = indexable && page.status === 'published';
+
+  return {
+    title: page.title,
+    description: page.description,
+    keywords: page.keywords,
+    alternates: getCompareAlternates(locale, page.slug),
+    robots: shouldIndex ? { index: true, follow: true } : { index: false, follow: false },
+    openGraph: {
+      title: page.title,
+      description: page.description,
+      type: 'article',
+      url: canonical,
+      locale: localeMap[locale] || 'en_US',
+      publishedTime: page.status === 'published' ? page.dates.datePublished : undefined,
+      modifiedTime: page.dates.dateModified,
+      images: [{ url: image, width: page.asset.width, height: page.asset.height, alt: page.asset.alt }]
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: page.title,
+      description: page.description,
+      images: [image]
+    }
+  };
+}

--- a/src/components/compare/ComparisonTables.tsx
+++ b/src/components/compare/ComparisonTables.tsx
@@ -1,15 +1,9 @@
 import type { CSSProperties } from 'react';
-import type { ComparisonTable } from '@/content/competitor';
+import type { CompareLocale, ComparisonTable } from '@/content/competitor';
+import { getComparisonCopy } from './comparisonCopy';
 
-const tableKindLabels = {
-  capability: '能力路径',
-  poc: '同条件验证',
-  tco: '成本与边界',
-  selection: '选型判据',
-  generic: '对照清单'
-} as const;
-
-export default function ComparisonTables({ table }: { table: ComparisonTable }) {
+export default function ComparisonTables({ table, locale }: { table: ComparisonTable; locale: CompareLocale }) {
+  const copy = getComparisonCopy(locale);
   const dataColumnCount = Math.max(table.columns.length - 1, 1);
   const gridTemplate = `minmax(9rem, 0.82fr) repeat(${dataColumnCount}, minmax(0, 1fr))`;
 
@@ -17,12 +11,12 @@ export default function ComparisonTables({ table }: { table: ComparisonTable }) 
     <div
       className={`comparison-table comparison-table-${table.kind}`}
       role="table"
-      aria-label={table.title || tableKindLabels[table.kind]}
+      aria-label={table.title || copy.tableLabels[table.kind]}
       style={{ '--comparison-grid': gridTemplate } as CSSProperties}
     >
       <div className="comparison-table-caption" aria-hidden="true">
-        <span>{tableKindLabels[table.kind]}</span>
-        <span>{table.rows.length} 项对照</span>
+        <span>{copy.tableLabels[table.kind]}</span>
+        <span>{copy.tableRowCount(table.rows.length)}</span>
       </div>
       <div className="comparison-table-head" role="row">
         {table.columns.map((column) => <div key={column} role="columnheader">{column}</div>)}
@@ -40,7 +34,7 @@ export default function ComparisonTables({ table }: { table: ComparisonTable }) 
                 className={index === 0 ? 'comparison-table-cell comparison-table-cell-key' : 'comparison-table-cell'}
                 key={`${row.id}-${index}`}
                 role="cell"
-                data-label={table.columns[index] || '字段'}
+                data-label={table.columns[index] || copy.fallbackCellLabel}
               >
                 {cell}
               </div>

--- a/src/components/compare/comparisonCopy.ts
+++ b/src/components/compare/comparisonCopy.ts
@@ -1,0 +1,100 @@
+import type { CompareLocale, ComparisonTableKind } from '@/content/competitor';
+
+const comparisonCopy = {
+  zh: {
+    previewBanner: '内容预览 · 页面状态待确认',
+    backLabel: '返回内容中心',
+    heroEyebrow: 'FastGPT 选型指南',
+    primaryHeroCta: '查看能力矩阵',
+    secondaryHeroCta: '打开官方资料',
+    trustStripAriaLabel: '资料核验信息',
+    heroSideLabel: '选型速览',
+    tocAriaLabel: '页面章节导航',
+    tocLabel: '比较维度',
+    coreKicker: '核心判断',
+    coreTitle: '按项目约束做选择',
+    contextLinksAriaLabel: '正文相关链接',
+    contextLinksLabel: '相关核对',
+    nextStepKicker: '继续核对',
+    nextStepTitle: '查看部署与采购细节',
+    nextStepDescription: '从私有化、许可和 POC 清单继续核对落地条件。',
+    ctaAriaLabel: '继续核验',
+    ctaKicker: 'FastGPT / compare',
+    ctaTitle: '把关键指标写进验收表',
+    ctaButton: '设计同条件 POC',
+    officialSourceLink: '官方资料入口',
+    fallbackCellLabel: '字段',
+    tableLabels: {
+      capability: '能力路径',
+      poc: '同条件验证',
+      tco: '成本与边界',
+      selection: '选型判据',
+      generic: '对照清单'
+    },
+    tableRowCount: (count: number) => `${count} 项对照`
+  },
+  en: {
+    previewBanner: 'Preview - page status pending review',
+    backLabel: 'Back to content center',
+    heroEyebrow: 'FastGPT selection guide',
+    primaryHeroCta: 'View capability matrix',
+    secondaryHeroCta: 'Open official docs',
+    trustStripAriaLabel: 'Verification details',
+    heroSideLabel: 'Selection overview',
+    tocAriaLabel: 'Page section navigation',
+    tocLabel: 'Comparison dimensions',
+    coreKicker: 'Key judgment',
+    coreTitle: 'Choose by project constraints',
+    contextLinksAriaLabel: 'Contextual related links',
+    contextLinksLabel: 'Related checks',
+    nextStepKicker: 'Keep checking',
+    nextStepTitle: 'Review deployment and procurement details',
+    nextStepDescription: 'Continue from private deployment, licensing, and POC checklists to verify rollout conditions.',
+    ctaAriaLabel: 'Continue validation',
+    ctaKicker: 'FastGPT / compare',
+    ctaTitle: 'Turn key metrics into an acceptance checklist',
+    ctaButton: 'Design a same-condition POC',
+    officialSourceLink: 'Official source',
+    fallbackCellLabel: 'Field',
+    tableLabels: {
+      capability: 'Capability path',
+      poc: 'Same-condition validation',
+      tco: 'Cost and boundaries',
+      selection: 'Selection criteria',
+      generic: 'Comparison checklist'
+    },
+    tableRowCount: (count: number) => `${count} items compared`
+  }
+} as const satisfies Record<
+  CompareLocale,
+  {
+    previewBanner: string;
+    backLabel: string;
+    heroEyebrow: string;
+    primaryHeroCta: string;
+    secondaryHeroCta: string;
+    trustStripAriaLabel: string;
+    heroSideLabel: string;
+    tocAriaLabel: string;
+    tocLabel: string;
+    coreKicker: string;
+    coreTitle: string;
+    contextLinksAriaLabel: string;
+    contextLinksLabel: string;
+    nextStepKicker: string;
+    nextStepTitle: string;
+    nextStepDescription: string;
+    ctaAriaLabel: string;
+    ctaKicker: string;
+    ctaTitle: string;
+    ctaButton: string;
+    officialSourceLink: string;
+    fallbackCellLabel: string;
+    tableLabels: Record<ComparisonTableKind, string>;
+    tableRowCount: (count: number) => string;
+  }
+>;
+
+export function getComparisonCopy(locale: CompareLocale) {
+  return comparisonCopy[locale];
+}

--- a/src/components/compare/comparisonHubCopy.ts
+++ b/src/components/compare/comparisonHubCopy.ts
@@ -1,0 +1,48 @@
+import type { CompareLocale } from '@/content/competitor';
+
+const comparisonHubCopy = {
+  zh: {
+    heroEyebrow: 'FastGPT 竞品入口',
+    heroTitle: 'FastGPT 竞品对比',
+    heroDescription:
+      '汇总 Dify、RAGFlow、MaxKB 与自研方案的对比页，按插件生态、复杂文档、采购可预测性和三年 TCO 进入细页核对。',
+    trustStripAriaLabel: '入口页核验信息',
+    pageCountLabel: '04 个页面',
+    cardCta: '查看对比',
+    cardPrefix: '进入页面',
+    relatedTitle: '继续阅读',
+    relatedDescription: '从入口页跳到更具体的选型、POC 与成本核对页面。',
+    compareLabel: '对比页合集'
+  },
+  en: {
+    heroEyebrow: 'FastGPT comparison hub',
+    heroTitle: 'FastGPT Comparison Hub',
+    heroDescription:
+      'Browse FastGPT with Dify, RAGFlow, MaxKB, and build-vs-buy pages from one indexable hub. Jump into fit, POC, support, and TCO checks you need for each route.',
+    trustStripAriaLabel: 'Hub verification details',
+    pageCountLabel: '04 pages',
+    cardCta: 'Open comparison',
+    cardPrefix: 'Open page',
+    relatedTitle: 'Continue reading',
+    relatedDescription: 'Jump from the hub into the page that matches your selection, POC, and budget check.',
+    compareLabel: 'Comparison cluster'
+  }
+} as const satisfies Record<
+  CompareLocale,
+  {
+    heroEyebrow: string;
+    heroTitle: string;
+    heroDescription: string;
+    trustStripAriaLabel: string;
+    pageCountLabel: string;
+    cardCta: string;
+    cardPrefix: string;
+    relatedTitle: string;
+    relatedDescription: string;
+    compareLabel: string;
+  }
+>;
+
+export function getComparisonHubCopy(locale: CompareLocale) {
+  return comparisonHubCopy[locale];
+}

--- a/src/components/home/Navbar.tsx
+++ b/src/components/home/Navbar.tsx
@@ -77,7 +77,8 @@ export default function Navbar({
     return pathname;
   })();
   const isFaqRoute = routeWithoutLang === '/faq' || routeWithoutLang.startsWith('/faq/');
-  const languageKeys = isFaqRoute ? faqLocaleCodes : Object.keys(localeNames);
+  const isCompareRoute = routeWithoutLang === '/compare' || routeWithoutLang.startsWith('/compare/');
+  const languageKeys = isFaqRoute || isCompareRoute ? faqLocaleCodes : Object.keys(localeNames);
   const getLocalizedPath = (value: string) => getOwnedLocaleUrl(value, routeWithoutLang);
 
   const handleSwitchLanguage = (value: string) => {

--- a/src/content/competitor/dify.ts
+++ b/src/content/competitor/dify.ts
@@ -1,5 +1,5 @@
 import { createComparisonPage } from './loader';
-import type { ComparisonPage } from './types';
+import type { ComparisonPage, ComparisonPagesByLocale } from './types';
 
 export const difyComparisonPage: ComparisonPage = createComparisonPage({
   slug: 'dify-vs-fastgpt',
@@ -27,6 +27,18 @@ export const difyComparisonPage: ComparisonPage = createComparisonPage({
     width: 1200,
     height: 630
   },
+  ctaCopy: {
+    primaryHeroCta: '核对插件与 SSO 边界',
+    nextStepTitle: '核对插件、SSO 与采购边界',
+    nextStepDescription: '从插件依赖、单点登录、审计和定价入口继续核对交付条件。',
+    ctaTitle: '把生态依赖写进验收表',
+    ctaButton: '设计插件生态 POC'
+  },
+  trustSignals: ['核验日期 2026-07-20', '基于官方公开资料', '按同条件 POC 验收'],
+  contextualLinks: [
+    { label: '对比页总览', target: '/zh/compare', locale: 'zh' },
+    { label: '复杂文档解析对照', target: '/zh/compare/ragflow-vs-fastgpt', locale: 'zh' }
+  ],
   internalLinks: [
     { label: '私有化部署边界', target: '/zh/faq/private-deployment-data-boundary', locale: 'zh' },
     { label: '开源版与商业版说明', target: '/zh/faq/open-source-vs-commercial-edition', locale: 'zh' },
@@ -34,5 +46,54 @@ export const difyComparisonPage: ComparisonPage = createComparisonPage({
   ],
   officialSource: 'https://docs.dify.ai/'
 });
+
+export const difyComparisonPages: ComparisonPagesByLocale = {
+  zh: difyComparisonPage,
+  en: createComparisonPage({
+    slug: 'dify-vs-fastgpt',
+    lang: 'en',
+    status: 'published',
+    title: 'Dify vs FastGPT: Plugin Ecosystem vs Knowledge Ops',
+    description:
+      'Compare Dify and FastGPT on plugins, knowledge ops, licensing, channels, and support. Use a same-condition POC to choose with evidence and acceptance criteria.',
+    heroSummary:
+      'Choose Dify when the team depends on a global plugin ecosystem and an overseas collaboration stack. Choose FastGPT when long-term knowledge-base operations, file-based Agents, and Chinese enterprise channels are core constraints.',
+    heroHighlights: [
+      { label: 'Dify', value: 'Global plugins and overseas collaboration' },
+      { label: 'FastGPT', value: 'Knowledge engineering, file-based Agents, Chinese channels' },
+      { label: 'Validation focus', value: 'Key integrations, knowledge operations, responsibility matrix' }
+    ],
+    keywords: ['Dify comparison', 'FastGPT', 'platform selection', 'vendor support', 'open source license'],
+    sourceFile: 'en/dify-vs-fastgpt.md',
+    dates: {
+      datePublished: '2026-08-04',
+      dateModified: '2026-08-08'
+    },
+    asset: {
+      path: '/images/compare/dify-vs-fastgpt.svg',
+      alt: 'Capability, validation, and selection path diagram for Dify and FastGPT',
+      width: 1200,
+      height: 630
+    },
+    ctaCopy: {
+      primaryHeroCta: 'Check plugin and SSO fit',
+      nextStepTitle: 'Check plugins, SSO, and procurement boundaries',
+      nextStepDescription: 'Continue from ecosystem dependencies, SSO, audit needs, and pricing to validate delivery conditions.',
+      ctaTitle: 'Turn ecosystem dependencies into POC checks',
+      ctaButton: 'Design the plugin-ecosystem POC'
+    },
+    trustSignals: ['Verified on 2026-07-20', 'Based on official public sources', 'Validated through same-condition POC'],
+    contextualLinks: [
+      { label: 'Comparison hub', target: '/compare', locale: 'en' },
+      { label: 'MaxKB procurement comparison', target: '/compare/maxkb-vs-fastgpt', locale: 'en' }
+    ],
+    internalLinks: [
+      { label: 'RAGFlow document-parsing comparison', target: '/compare/ragflow-vs-fastgpt', locale: 'en' },
+      { label: 'Build-vs-buy TCO model', target: '/compare/self-build-vs-platform', locale: 'en' },
+      { label: 'Official pricing page', target: '/price', locale: 'en' }
+    ],
+    officialSource: 'https://docs.dify.ai/'
+  })
+};
 
 export default difyComparisonPage;

--- a/src/content/competitor/index.ts
+++ b/src/content/competitor/index.ts
@@ -1,20 +1,29 @@
-import difyComparisonPage from './dify';
-import maxkbComparisonPage from './maxkb';
-import ragflowComparisonPage from './ragflow';
-import selfBuildComparisonPage from './selfBuild';
-import type { ComparisonPage } from './types';
+import { difyComparisonPages } from './dify';
+import { maxkbComparisonPages } from './maxkb';
+import { ragflowComparisonPages } from './ragflow';
+import { selfBuildComparisonPages } from './selfBuild';
+import type { CompareLocale, ComparisonPage, ComparisonPagesByLocale } from './types';
 
 export const comparisonPages = {
-  'dify-vs-fastgpt': difyComparisonPage,
-  'self-build-vs-platform': selfBuildComparisonPage,
-  'ragflow-vs-fastgpt': ragflowComparisonPage,
-  'maxkb-vs-fastgpt': maxkbComparisonPage
-} as const satisfies Record<string, ComparisonPage>;
+  'dify-vs-fastgpt': difyComparisonPages,
+  'ragflow-vs-fastgpt': ragflowComparisonPages,
+  'maxkb-vs-fastgpt': maxkbComparisonPages,
+  'self-build-vs-platform': selfBuildComparisonPages
+} as const satisfies Record<string, ComparisonPagesByLocale>;
 
 export const comparisonSlugs = Object.keys(comparisonPages) as Array<keyof typeof comparisonPages>;
+export const comparisonLocales = ['zh', 'en'] as const satisfies CompareLocale[];
 
-export function getComparisonPage(slug: string) {
-  return comparisonPages[slug as keyof typeof comparisonPages];
+export function resolveCompareLocale(locale: string): CompareLocale {
+  return locale === 'zh' ? 'zh' : 'en';
+}
+
+export function getComparisonPage(slug: string, locale: CompareLocale): ComparisonPage | undefined {
+  return comparisonPages[slug as keyof typeof comparisonPages]?.[locale];
+}
+
+export function getComparisonPagesForLocale(locale: CompareLocale) {
+  return comparisonSlugs.map((slug) => comparisonPages[slug][locale]);
 }
 
 export type * from './types';

--- a/src/content/competitor/loader.ts
+++ b/src/content/competitor/loader.ts
@@ -26,21 +26,32 @@ function cellsFromTableRow(line: string) {
 }
 
 function tableKind(title: string | undefined, fallbackText = ''): ComparisonTableKind {
-  const value = title || '';
-  if (/能力|产品重心|实现路径|长期工作|工作组/.test(value)) return 'capability';
-  if (/POC|验证|测量|怎么自己|必测/.test(value)) return 'poc';
-  if (/TCO|成本|采购形态|许可证|许可|公开边界|买断/.test(value)) return 'tco';
-  if (/选型建议|第一成败因素|第一约束/.test(value)) return 'selection';
-  if (/能力|实现路径|长期工作|工作组/.test(fallbackText)) return 'capability';
-  if (/POC|验证|测量|必测/.test(fallbackText)) return 'poc';
-  if (/TCO|成本|采购形态|许可证|许可|公开边界|买断/.test(fallbackText)) return 'tco';
+  const value = `${title || ''} ${fallbackText}`;
+  if (/能力|产品重心|实现路径|长期工作|工作组|capability|product focus|implementation path|long-term work|work group/i.test(value)) {
+    return 'capability';
+  }
+  if (/POC|验证|测量|怎么自己|必测|poc|validation|measurement|same-condition|must test/i.test(value)) {
+    return 'poc';
+  }
+  if (/TCO|成本|采购形态|许可证|许可|公开边界|买断|tco|cost|procurement|license|licensing|boundary|buyout/i.test(value)) {
+    return 'tco';
+  }
+  if (/选型建议|第一成败因素|第一约束|selection|criteria|recommendation|decision/i.test(value)) {
+    return 'selection';
+  }
   return 'generic';
 }
 
 function evidenceStatus(text: string) {
-  if (/待合同|合同确认|合同验收/.test(text)) return 'contract-required' as const;
-  if (/待 POC|待POC|POC|自行验证|同条件/.test(text)) return 'poc-required' as const;
-  if (/未列出|未证明|未固化|未说明|未公开|公开资料未/.test(text)) return 'not-publicly-listed' as const;
+  if (/待合同|合同确认|合同验收|contract required|contract confirmation|to be confirmed in contract/i.test(text)) {
+    return 'contract-required' as const;
+  }
+  if (/待 POC|待POC|POC|自行验证|同条件|poc required|same-condition|requires pOC|requires POC/i.test(text)) {
+    return 'poc-required' as const;
+  }
+  if (/未列出|未证明|未固化|未说明|未公开|公开资料未|not publicly listed|not publicly disclosed|not official/i.test(text)) {
+    return 'not-publicly-listed' as const;
+  }
   return 'official-public' as const;
 }
 
@@ -81,9 +92,9 @@ function parseDocument(markdown: string) {
       cursor += 1;
       continue;
     }
-    if (/^> \*\*事实来源\*\*/.test(line)) break;
+    if (/^> \*\*(事实来源|Sources?|Source)\*\*/.test(line)) break;
     if (/^---+$/.test(line)) {
-      if (/^> \*\*事实来源\*\*/.test(lines[cursor + 1]?.trim() || '')) break;
+      if (/^> \*\*(事实来源|Sources?|Source)\*\*/.test(lines[cursor + 1]?.trim() || '')) break;
       cursor += 1;
       continue;
     }

--- a/src/content/competitor/maxkb.ts
+++ b/src/content/competitor/maxkb.ts
@@ -1,5 +1,5 @@
 import { createComparisonPage } from './loader';
-import type { ComparisonPage } from './types';
+import type { ComparisonPage, ComparisonPagesByLocale } from './types';
 
 export const maxkbComparisonPage: ComparisonPage = createComparisonPage({
   slug: 'maxkb-vs-fastgpt',
@@ -27,6 +27,18 @@ export const maxkbComparisonPage: ComparisonPage = createComparisonPage({
     width: 1200,
     height: 630
   },
+  ctaCopy: {
+    primaryHeroCta: '核对采购与支持边界',
+    nextStepTitle: '核对买断、支持档位与次年维保',
+    nextStepDescription: '从私有化边界、版本授权、POC 清单和支持责任继续核对采购条件。',
+    ctaTitle: '把买断、维保与支持写进三年表',
+    ctaButton: '核算三年 TCO'
+  },
+  trustSignals: ['核验日期 2026-07-20', '基于官方公开资料', '按同条件 POC 验收'],
+  contextualLinks: [
+    { label: '对比页总览', target: '/zh/compare', locale: 'zh' },
+    { label: '自研与采购成本模型', target: '/zh/compare/self-build-vs-platform', locale: 'zh' }
+  ],
   internalLinks: [
     { label: '私有化部署边界', target: '/zh/faq/private-deployment-data-boundary', locale: 'zh' },
     { label: '开源版与商业版说明', target: '/zh/faq/open-source-vs-commercial-edition', locale: 'zh' },
@@ -34,5 +46,54 @@ export const maxkbComparisonPage: ComparisonPage = createComparisonPage({
   ],
   officialSource: 'https://maxkb.cn/docs/'
 });
+
+export const maxkbComparisonPages: ComparisonPagesByLocale = {
+  zh: maxkbComparisonPage,
+  en: createComparisonPage({
+    slug: 'maxkb-vs-fastgpt',
+    lang: 'en',
+    status: 'published',
+    title: 'MaxKB vs FastGPT: Procurement vs Production Control',
+    description:
+      'Compare MaxKB and FastGPT on private deployment, governance, support tiers, and three-year TCO before procurement. Confirm terms with a same-condition POC.',
+    heroSummary:
+      'Include MaxKB as a candidate when private delivery and procurement predictability come first. Prioritize FastGPT when fine-grained knowledge governance, workflow recovery, and multi-channel operations come first.',
+    heroHighlights: [
+      { label: 'MaxKB', value: 'Domestic private delivery and procurement model' },
+      { label: 'FastGPT', value: 'Fine-grained governance, workflows, multi-channel operations' },
+      { label: 'Validation focus', value: 'Three-year TCO, support tiers, next-year maintenance' }
+    ],
+    keywords: ['MaxKB comparison', 'FastGPT', 'private deployment', 'three-year TCO', 'code sandbox'],
+    sourceFile: 'en/maxkb-vs-fastgpt.md',
+    dates: {
+      datePublished: '2026-08-04',
+      dateModified: '2026-08-08'
+    },
+    asset: {
+      path: '/images/compare/maxkb-vs-fastgpt.svg',
+      alt: 'Procurement, governance, POC, and three-year cost comparison diagram for MaxKB and FastGPT',
+      width: 1200,
+      height: 630
+    },
+    ctaCopy: {
+      primaryHeroCta: 'Check procurement and support terms',
+      nextStepTitle: 'Check buyout, support tiers, and renewal maintenance',
+      nextStepDescription: 'Continue from private deployment, licensing, POC checks, and support responsibility to validate procurement terms.',
+      ctaTitle: 'Put buyout, maintenance, and support into the TCO',
+      ctaButton: 'Calculate the three-year TCO'
+    },
+    trustSignals: ['Verified on 2026-07-20', 'Based on official public sources', 'Validated through same-condition POC'],
+    contextualLinks: [
+      { label: 'Comparison hub', target: '/compare', locale: 'en' },
+      { label: 'Dify plugin-ecosystem comparison', target: '/compare/dify-vs-fastgpt', locale: 'en' }
+    ],
+    internalLinks: [
+      { label: 'Build-vs-buy TCO model', target: '/compare/self-build-vs-platform', locale: 'en' },
+      { label: 'RAGFlow document-parsing comparison', target: '/compare/ragflow-vs-fastgpt', locale: 'en' },
+      { label: 'Official pricing page', target: '/price', locale: 'en' }
+    ],
+    officialSource: 'https://maxkb.cn/docs/'
+  })
+};
 
 export default maxkbComparisonPage;

--- a/src/content/competitor/ragflow.ts
+++ b/src/content/competitor/ragflow.ts
@@ -1,5 +1,5 @@
 import { createComparisonPage } from './loader';
-import type { ComparisonPage } from './types';
+import type { ComparisonPage, ComparisonPagesByLocale } from './types';
 
 export const ragflowComparisonPage: ComparisonPage = createComparisonPage({
   slug: 'ragflow-vs-fastgpt',
@@ -27,12 +27,73 @@ export const ragflowComparisonPage: ComparisonPage = createComparisonPage({
     width: 1200,
     height: 630
   },
+  ctaCopy: {
+    primaryHeroCta: '查看复杂文档判据',
+    nextStepTitle: '核对文档解析、链路恢复与支持边界',
+    nextStepDescription: '从复杂 PDF、OCR、Langfuse、恢复链路和 POC 清单继续核对落地条件。',
+    ctaTitle: '用同一批文档验证解析质量',
+    ctaButton: '设计复杂文档 POC'
+  },
+  trustSignals: ['核验日期 2026-07-20', '基于官方公开资料', '按同条件 POC 验收'],
+  contextualLinks: [
+    { label: '对比页总览', target: '/zh/compare', locale: 'zh' },
+    { label: '三年成本模型', target: '/zh/compare/self-build-vs-platform', locale: 'zh' }
+  ],
   internalLinks: [
-    { label: '复杂文档解析能力说明', target: '/zh/faq/poc-design-checklist', locale: 'zh' },
+    { label: '复杂文档解析能力说明', target: '/zh/faq/complex-document-parsing', locale: 'zh' },
     { label: '私有化部署边界', target: '/zh/faq/private-deployment-data-boundary', locale: 'zh' },
     { label: 'POC 测量清单', target: '/zh/faq/poc-design-checklist', locale: 'zh' }
   ],
   officialSource: 'https://ragflow.io/docs/'
 });
+
+export const ragflowComparisonPages: ComparisonPagesByLocale = {
+  zh: ragflowComparisonPage,
+  en: createComparisonPage({
+    slug: 'ragflow-vs-fastgpt',
+    lang: 'en',
+    status: 'published',
+    title: 'RAGFlow vs FastGPT: Complex Docs vs Delivery Chain',
+    description:
+      'Compare RAGFlow and FastGPT on document parsing, knowledge ops, workflow recovery, channels, and support before a same-document POC with your own rubric.',
+    heroSummary:
+      'Prioritize RAGFlow validation when scanned files and complex-layout parsing are the primary job. Prioritize FastGPT when knowledge operations, workflow recovery, Chinese channels, and vendor support become core constraints.',
+    heroHighlights: [
+      { label: 'RAGFlow', value: 'Scanned files and complex-layout parsing' },
+      { label: 'FastGPT', value: 'Knowledge operations, workflow recovery, Chinese channels' },
+      { label: 'Validation focus', value: 'Same documents, chain recovery, support responsibility' }
+    ],
+    keywords: ['RAGFlow comparison', 'FastGPT', 'complex document parsing', 'golden-set validation', 'open source license'],
+    sourceFile: 'en/ragflow-vs-fastgpt.md',
+    dates: {
+      datePublished: '2026-08-04',
+      dateModified: '2026-08-08'
+    },
+    asset: {
+      path: '/images/compare/ragflow-vs-fastgpt.svg',
+      alt: 'Complex document, POC, and full-chain comparison diagram for RAGFlow and FastGPT',
+      width: 1200,
+      height: 630
+    },
+    ctaCopy: {
+      primaryHeroCta: 'Check document parsing criteria',
+      nextStepTitle: 'Check parsing, recovery, and support boundaries',
+      nextStepDescription: 'Continue from complex PDFs, OCR, Langfuse, recovery paths, and POC checklists to validate rollout conditions.',
+      ctaTitle: 'Validate parsing quality with the same documents',
+      ctaButton: 'Design the document POC'
+    },
+    trustSignals: ['Verified on 2026-07-20', 'Based on official public sources', 'Validated through same-condition POC'],
+    contextualLinks: [
+      { label: 'Comparison hub', target: '/compare', locale: 'en' },
+      { label: 'Official pricing page', target: '/price', locale: 'en' }
+    ],
+    internalLinks: [
+      { label: 'Dify plugin-ecosystem comparison', target: '/compare/dify-vs-fastgpt', locale: 'en' },
+      { label: 'Build-vs-buy TCO model', target: '/compare/self-build-vs-platform', locale: 'en' },
+      { label: 'MaxKB procurement comparison', target: '/compare/maxkb-vs-fastgpt', locale: 'en' }
+    ],
+    officialSource: 'https://ragflow.io/docs/'
+  })
+};
 
 export default ragflowComparisonPage;

--- a/src/content/competitor/selfBuild.ts
+++ b/src/content/competitor/selfBuild.ts
@@ -1,5 +1,5 @@
 import { createComparisonPage } from './loader';
-import type { ComparisonPage } from './types';
+import type { ComparisonPage, ComparisonPagesByLocale } from './types';
 
 export const selfBuildComparisonPage: ComparisonPage = createComparisonPage({
   slug: 'self-build-vs-platform',
@@ -27,6 +27,18 @@ export const selfBuildComparisonPage: ComparisonPage = createComparisonPage({
     width: 1200,
     height: 630
   },
+  ctaCopy: {
+    primaryHeroCta: '核算自研长期成本',
+    nextStepTitle: '核算平台工程、运维和升级成本',
+    nextStepDescription: '从人力、运行时、安全治理、回滚与支持边界继续核对三年预算。',
+    ctaTitle: '把平台工程人天算进预算',
+    ctaButton: '建立三年成本表'
+  },
+  trustSignals: ['核验日期 2026-07-20', '基于官方公开资料', '按同条件 POC 验收'],
+  contextualLinks: [
+    { label: '对比页总览', target: '/zh/compare', locale: 'zh' },
+    { label: '采购与支持边界对照', target: '/zh/compare/maxkb-vs-fastgpt', locale: 'zh' }
+  ],
   internalLinks: [
     { label: '开源版与商业版说明', target: '/zh/faq/open-source-vs-commercial-edition', locale: 'zh' },
     { label: '私有化部署边界', target: '/zh/faq/private-deployment-data-boundary', locale: 'zh' },
@@ -34,5 +46,54 @@ export const selfBuildComparisonPage: ComparisonPage = createComparisonPage({
   ],
   officialSource: 'https://doc.fastgpt.cn/'
 });
+
+export const selfBuildComparisonPages: ComparisonPagesByLocale = {
+  zh: selfBuildComparisonPage,
+  en: createComparisonPage({
+    slug: 'self-build-vs-platform',
+    lang: 'en',
+    status: 'published',
+    title: 'Self-Build vs Platform: Three-Year Build-vs-Buy TCO',
+    description:
+      'Compare self-build, open source, and platform options across labor, runtime, security, operations, upgrades, and support over three years. Keep TCO auditable.',
+    heroSummary:
+      'Self-building or running open source directly gives more room when a platform engineering team already exists and wants deep control. A platform solution fits teams that need fast launch, a mature runtime, an upgrade path, and support channels.',
+    heroHighlights: [
+      { label: 'Self-build / open source', value: 'Deep control and self-managed operations' },
+      { label: 'Platform solution', value: 'Ready runtime, upgrade path, vendor support' },
+      { label: 'Validation focus', value: 'Three-year TCO, failure recovery, migration cost' }
+    ],
+    keywords: ['self-build cost', 'three-year TCO', 'platform engineering', 'vendor support', 'open source self-hosting'],
+    sourceFile: 'en/self-build-vs-platform.md',
+    dates: {
+      datePublished: '2026-08-04',
+      dateModified: '2026-08-08'
+    },
+    asset: {
+      path: '/images/compare/self-build-vs-platform.svg',
+      alt: 'Cost-structure diagram for self-build and platform options across parsing, runtime, security, and operations',
+      width: 1200,
+      height: 630
+    },
+    ctaCopy: {
+      primaryHeroCta: 'Model build-vs-buy cost',
+      nextStepTitle: 'Model labor, runtime, security, and upgrade cost',
+      nextStepDescription: 'Continue from platform engineering, operations, rollback, and support boundaries to validate the three-year budget.',
+      ctaTitle: 'Put platform-engineering labor into the budget',
+      ctaButton: 'Build the three-year cost table'
+    },
+    trustSignals: ['Verified on 2026-07-20', 'Based on official public sources', 'Validated through same-condition POC'],
+    contextualLinks: [
+      { label: 'Comparison hub', target: '/compare', locale: 'en' },
+      { label: 'Dify plugin-ecosystem comparison', target: '/compare/dify-vs-fastgpt', locale: 'en' }
+    ],
+    internalLinks: [
+      { label: 'MaxKB procurement comparison', target: '/compare/maxkb-vs-fastgpt', locale: 'en' },
+      { label: 'RAGFlow document-parsing comparison', target: '/compare/ragflow-vs-fastgpt', locale: 'en' },
+      { label: 'Official pricing page', target: '/price', locale: 'en' }
+    ],
+    officialSource: 'https://doc.fastgpt.cn/'
+  })
+};
 
 export default selfBuildComparisonPage;

--- a/src/content/competitor/types.ts
+++ b/src/content/competitor/types.ts
@@ -1,4 +1,5 @@
 export type PageStatus = 'preview' | 'published';
+export type CompareLocale = 'zh' | 'en';
 
 export type EvidenceStatus =
   | 'official-public'
@@ -45,7 +46,7 @@ export interface ComparisonSection {
 export interface InternalLink {
   label: string;
   target: string;
-  locale: string;
+  locale: CompareLocale;
 }
 
 export interface PageAsset {
@@ -60,6 +61,15 @@ export interface ComparisonHighlight {
   value: string;
 }
 
+export interface ComparisonPageCtaCopy {
+  primaryHeroCta?: string;
+  secondaryHeroCta?: string;
+  nextStepTitle?: string;
+  nextStepDescription?: string;
+  ctaTitle?: string;
+  ctaButton?: string;
+}
+
 export interface DateFields {
   datePublished: string;
   dateModified: string;
@@ -67,7 +77,7 @@ export interface DateFields {
 
 export interface ComparisonPage {
   slug: string;
-  lang: 'zh';
+  lang: CompareLocale;
   status: PageStatus;
   title: string;
   description: string;
@@ -78,6 +88,11 @@ export interface ComparisonPage {
   sections: ComparisonSection[];
   dates: DateFields;
   asset: PageAsset;
+  ctaCopy?: ComparisonPageCtaCopy;
+  trustSignals?: string[];
+  contextualLinks?: InternalLink[];
   internalLinks: InternalLink[];
   officialSource: string;
 }
+
+export type ComparisonPagesByLocale = Record<CompareLocale, ComparisonPage>;

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,21 +1,46 @@
 import { Metadata } from 'next';
+import type { CompareLocale } from '@/content/competitor';
 import { localeMap, supportedLocaleCodes } from '@/lib/locales';
 import { getLocaleHreflang, getOwnedFaqUrl, getOwnedLocaleUrl } from '@/lib/siteRouting';
 
 export { localeMap };
 
-export function getCompareCanonicalUrl(slug: string) {
-  return getOwnedLocaleUrl('zh', `/compare/${slug}`);
+export function getCompareCanonicalUrl(locale: CompareLocale, slug: string) {
+  return getOwnedLocaleUrl(locale, `/compare/${slug}`);
 }
 
-export function getCompareAlternates(slug: string): Metadata['alternates'] {
-  const canonical = getCompareCanonicalUrl(slug);
+export function getCompareAlternates(locale: CompareLocale, slug: string): Metadata['alternates'] {
+  const canonical = getCompareCanonicalUrl(locale, slug);
+  const englishUrl = getOwnedLocaleUrl('en', `/compare/${slug}`);
+  const chineseUrl = getOwnedLocaleUrl('zh', `/compare/${slug}`);
+
   return {
     canonical,
     languages: {
-      zh: canonical,
-      'zh-CN': canonical,
-      'x-default': canonical
+      en: englishUrl,
+      zh: chineseUrl,
+      'zh-CN': chineseUrl,
+      'x-default': englishUrl
+    }
+  };
+}
+
+export function getCompareHubCanonicalUrl(locale: CompareLocale) {
+  return getOwnedLocaleUrl(locale, '/compare');
+}
+
+export function getCompareHubAlternates(locale: CompareLocale): Metadata['alternates'] {
+  const canonical = getCompareHubCanonicalUrl(locale);
+  const englishUrl = getOwnedLocaleUrl('en', '/compare');
+  const chineseUrl = getOwnedLocaleUrl('zh', '/compare');
+
+  return {
+    canonical,
+    languages: {
+      en: englishUrl,
+      zh: chineseUrl,
+      'zh-CN': chineseUrl,
+      'x-default': englishUrl
     }
   };
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -184,7 +184,8 @@ body {
 }
 
 .comparison-page,
-.comparison-preview-banner {
+.comparison-preview-banner,
+.comparison-footer {
   position: relative;
   z-index: 1;
 }
@@ -414,6 +415,23 @@ body {
 
 .comparison-button-secondary:hover { border-color: var(--comparison-accent); background: var(--comparison-accent-soft); }
 
+.comparison-trust-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px 18px;
+  margin-top: 20px;
+  padding-top: 18px;
+  border-top: 1px solid var(--comparison-line);
+  color: var(--comparison-muted);
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.comparison-trust-strip span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .comparison-hero-side {
   display: flex;
   flex-direction: column;
@@ -568,6 +586,51 @@ body {
   line-height: 1.62;
 }
 
+.comparison-context-links {
+  margin-top: 28px;
+  padding-top: 22px;
+  border-top: 1px solid var(--comparison-line);
+}
+
+.comparison-context-links > span {
+  display: block;
+  color: var(--comparison-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  line-height: 17px;
+  text-transform: uppercase;
+}
+
+.comparison-context-links > div {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.comparison-context-links a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 44px;
+  padding: 11px 13px;
+  border: 1px solid var(--comparison-line-strong);
+  border-radius: 4px;
+  color: var(--comparison-text);
+  font-size: 13px;
+  line-height: 18px;
+  text-decoration: none;
+  transition: border-color 180ms ease, background 180ms ease, transform 180ms ease;
+}
+
+.comparison-context-links a:hover {
+  border-color: var(--comparison-accent);
+  background: var(--comparison-accent-soft);
+  transform: translateY(-1px);
+}
+
 .comparison-section {
   scroll-margin-top: 84px;
 }
@@ -699,6 +762,232 @@ body {
 .comparison-cta-text-link { display: inline-flex; align-items: center; gap: 7px; color: var(--comparison-body); font-size: 13px; text-decoration: none; }
 .comparison-cta-text-link:hover { color: var(--comparison-text); }
 
+.comparison-hub-inner {
+  width: min(100%, 1200px);
+  margin: 0 auto;
+  padding: 64px 0 0;
+}
+
+.comparison-hub-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 48px;
+  padding: 0 40px;
+  border-right: 1px solid var(--comparison-line);
+  border-bottom: 1px solid var(--comparison-line);
+  border-left: 1px solid var(--comparison-line);
+  color: var(--comparison-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.comparison-hub-topline-code {
+  color: var(--comparison-accent);
+}
+
+.comparison-hub-hero {
+  border-right: 1px solid var(--comparison-line);
+  border-bottom: 1px solid var(--comparison-line);
+  border-left: 1px solid var(--comparison-line);
+  background: var(--comparison-surface);
+}
+
+.comparison-hub-hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 7fr) minmax(340px, 5fr);
+  border-top: 1px solid var(--comparison-line);
+}
+
+.comparison-hub-hero-copy,
+.comparison-hub-feature {
+  min-width: 0;
+  padding: 56px 40px 60px;
+}
+
+.comparison-hub-hero-copy {
+  border-right: 1px solid var(--comparison-line);
+}
+
+.comparison-hub-hero-copy h1 {
+  max-width: 12ch;
+  margin: 24px 0 0;
+  color: var(--comparison-text);
+  font-family: var(--home-font-display);
+  font-size: 58px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: -0.05em;
+  text-wrap: balance;
+}
+
+.comparison-hub-hero-copy p {
+  max-width: 62ch;
+  margin: 22px 0 0;
+  color: var(--comparison-body);
+  font-size: 18px;
+  line-height: 1.75;
+}
+
+.comparison-hub-trust-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px 18px;
+  margin-top: 22px;
+  color: var(--comparison-muted);
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.comparison-hub-trust-strip span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.comparison-hub-feature {
+  background: #ffffff;
+}
+
+.comparison-hub-feature h2 {
+  max-width: 10ch;
+  margin: 18px 0 0;
+  color: var(--comparison-text);
+  font-family: var(--home-font-display);
+  font-size: 32px;
+  font-weight: 600;
+  line-height: 1.1;
+  letter-spacing: -0.04em;
+}
+
+.comparison-hub-feature p {
+  max-width: 32ch;
+  margin: 16px 0 0;
+  color: var(--comparison-body);
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+.comparison-hub-mini-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+  margin-top: 26px;
+}
+
+.comparison-hub-mini-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 54px;
+  padding: 13px 14px;
+  border: 1px solid var(--comparison-line-strong);
+  border-radius: 4px;
+  color: var(--comparison-text);
+  font-size: 13px;
+  line-height: 18px;
+  text-decoration: none;
+  transition: border-color 180ms ease, background 180ms ease, transform 180ms ease;
+}
+
+.comparison-hub-mini-card:hover {
+  border-color: var(--comparison-accent);
+  background: var(--comparison-accent-soft);
+  transform: translateY(-1px);
+}
+
+.comparison-hub-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-top: 1px solid var(--comparison-line);
+  border-right: 1px solid var(--comparison-line);
+  border-bottom: 1px solid var(--comparison-line);
+  border-left: 1px solid var(--comparison-line);
+}
+
+.comparison-hub-card {
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  gap: 18px;
+  padding: 28px 28px 30px;
+  border-right: 1px solid var(--comparison-line);
+  color: var(--comparison-text);
+  text-decoration: none;
+  background: #ffffff;
+  transition: background 180ms ease, transform 180ms ease;
+}
+
+.comparison-hub-card:nth-child(2n) {
+  border-right: 0;
+}
+
+.comparison-hub-card:hover {
+  background: var(--comparison-accent-soft);
+  transform: translateY(-2px);
+}
+
+.comparison-hub-card img {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1200 / 630;
+  border: 1px solid var(--comparison-line);
+  border-radius: 4px;
+  background: #e8eef8;
+  filter: saturate(0.72) contrast(1.04);
+}
+
+.comparison-hub-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--comparison-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.comparison-hub-card-index {
+  color: var(--comparison-accent);
+}
+
+.comparison-hub-card-copy {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.comparison-hub-card-copy h2 {
+  margin: 0;
+  color: var(--comparison-text);
+  font-family: var(--home-font-display);
+  font-size: 28px;
+  font-weight: 600;
+  line-height: 1.1;
+  letter-spacing: -0.04em;
+}
+
+.comparison-hub-card-copy p {
+  margin: 14px 0 0;
+  color: var(--comparison-body);
+  font-size: 15px;
+  line-height: 1.72;
+}
+
+.comparison-hub-card-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 18px;
+  color: var(--comparison-accent);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 18px;
+}
+
 @media (max-width: 900px) {
   .comparison-hero { grid-template-columns: 1fr; }
   .comparison-hero-copy { border-right: 0; border-bottom: 1px solid var(--comparison-line); }
@@ -710,18 +999,26 @@ body {
   .comparison-section-content,
   .comparison-link-content { grid-column: span 7; }
   .comparison-link-grid { grid-template-columns: 1fr; }
+  .comparison-hub-hero-grid,
+  .comparison-hub-grid { grid-template-columns: 1fr; }
+  .comparison-hub-card:nth-child(2n) { border-right: 1px solid var(--comparison-line); }
 }
 
 @media (max-width: 720px) {
   .comparison-page-inner { width: 100%; padding-top: 64px; }
+  .comparison-hub-inner { width: 100%; padding-top: 64px; }
   .comparison-topline { min-height: 46px; padding: 0 20px; }
+  .comparison-hub-topline { min-height: 46px; padding: 0 20px; }
   .comparison-topline-code { display: none; }
+  .comparison-hub-topline-code { display: none; }
   .comparison-hero-copy,
   .comparison-hero-side { padding: 48px 20px; }
   .comparison-hero h1 { margin-top: 24px; font-size: 46px; line-height: 0.98; }
   .comparison-dek { margin-top: 24px; font-size: 16px; line-height: 1.72; }
   .comparison-hero-actions { flex-direction: column; align-items: stretch; margin-top: 28px; }
   .comparison-button { width: 100%; }
+  .comparison-trust-strip,
+  .comparison-hub-trust-strip { grid-template-columns: 1fr; gap: 8px; }
   .comparison-hero-highlights { margin-top: 24px; }
   .comparison-hero-highlights > div { grid-template-columns: 88px minmax(0, 1fr); }
   .comparison-hero-figure { padding-top: 30px; }
@@ -736,18 +1033,27 @@ body {
   .comparison-section-lead,
   .comparison-link-lead,
   .comparison-cta > div:first-child { padding: 40px 20px 28px; border-right: 0; border-bottom: 1px solid var(--comparison-line); }
+  .comparison-hub-hero-copy,
+  .comparison-hub-feature { padding: 40px 20px 28px; border-right: 0; border-bottom: 1px solid var(--comparison-line); }
   .comparison-intro-lead h3,
   .comparison-link-lead h3 { max-width: 14ch; font-size: 28px; }
+  .comparison-hub-hero-copy h1 { max-width: 14ch; font-size: 40px; }
+  .comparison-hub-feature h2 { max-width: 14ch; font-size: 28px; }
   .comparison-intro,
   .comparison-section-content,
   .comparison-link-content,
   .comparison-cta-actions { padding: 34px 20px 48px; }
+  .comparison-hub-card { padding: 22px 20px 24px; }
+  .comparison-hub-card-copy h2 { font-size: 24px; }
+  .comparison-hub-card-copy p { font-size: 14px; line-height: 1.68; }
   .comparison-intro,
   .comparison-section-content { font-size: 16px; line-height: 1.82; }
   .comparison-intro p:first-child { font-size: 20px; line-height: 1.62; }
   .comparison-section-lead { position: static; min-height: 0; }
   .comparison-section-lead h2 { max-width: 14ch; margin-top: 16px; font-size: 30px; }
   .comparison-section-content h3 { font-size: 20px; }
+  .comparison-context-links > div,
+  .comparison-hub-mini-grid { grid-template-columns: 1fr; }
   .comparison-table { margin: 28px 0 34px; border-radius: 4px; background: transparent; overflow: visible; }
   .comparison-table-caption { padding: 10px 0; border-bottom: 1px solid var(--comparison-line); }
   .comparison-table-head { display: none; }


### PR DESCRIPTION
## Summary

This branch extends the FastGPT marketing SEO cleanup with a `/compare` hub, tighter English metadata, and localized route support across the compare pages. It also carries the earlier SEO hardening commits already stacked on this branch, so the PR lands the full SEO bundle in one pass.

## Changes

- Added a localized `/compare` hub and supporting compare routes.
- Tightened English titles and descriptions on the four comparison pages.
- Added page-specific CTA copy, trust strips, and contextual support links.
- Updated sitemap, redirects, SEO helpers, and the i18n SEO verification script.
- Kept bilingual canonical, hreflang, robots, and JSON-LD coverage aligned.

## Verification

- [x] `npm exec tsc -- --noEmit --incremental false`
- [x] `npm run lint`
- [x] `.io build`
- [x] `.io npm run verify:i18n-seo`
- [x] `.cn build`
- [x] `.cn npm run verify:i18n-seo`

## TDD Audit

| Test commit | Impl commit | gate_status |
|---|---|---|
| `4d14774` fix: harden FAQ social metadata and security headers (#185) | — | missing |
| `
45048d` fix: improve homepage SEO and mobile performance (#186) | — | missing |
| `
3e19d9` fix: normalize FAQ SEO metadata and heading hierarchy (#187) | — | missing |
| `
a310e6` feat: redesign FAQ pages and canonicalize Chinese routes (#190) | — | missing |
| `
69508e` feat: normalize default language URLs across deployments (#191) | — | missing |
| `
7764ff` feat: define multilingual SEO ownership across FastGPT sites (#192) | — | missing |
| `
c1adeb` feat: add SEO-ready FastGPT technical center (#193) | — | missing |
| `
fb6b8e` feat: publish W2 website content and V1.2 comparisons (#188) | — | missing |
| `
b4ad3d` feat: add compare SEO hub and tighten metadata | — | missing |

Aggregate: 0 skill, 0 fallback, 0 exempt, 9 missing.

gate_status: skill=0, fallback=0, exempt=0, missing=9
