### PR TITLE
fix: update AI Proxy footer link

### DIFF
--- a/src/components/home/Footer.tsx
+++ b/src/components/home/Footer.tsx
@@ -48,7 +48,7 @@ function buildColumns(t: FooterT['columns']): Column[] {
       width: 150,
       items: [
         { label: 'Sealos', href: 'https://sealos.run/?s=%E9%A6%96%E9%A1%B5', external: true },
-        { label: 'AI Proxy', href: 'https://sealos.run/aiproxy/?s=AiProxy', external: true }
+        { label: 'AI Proxy', href: 'https://sealos.run/products/aiproxy', external: true }
       ]
     },
     {


### PR DESCRIPTION
Update the footer AI Proxy partner link to the current Sealos product page.

Old URL:
https://sealos.run/aiproxy/?s=AiProxy

New URL:
https://sealos.run/products/aiproxy