### PR TITLE
feat: add native consultation form

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ npm install
 npm run dev
 ```
 
+商务咨询表单需要在构建时配置 CRM API 地址（必须包含 `/api/v1`）：
+
+```bash
+NEXT_PUBLIC_CRM_API_URL=https://crm.example.com/api/v1 npm run build
+```
+
+同时在 CRM 服务中将官网域名加入 `CORS_ORIGINS`。如果未配置
+`NEXT_PUBLIC_CRM_API_URL`，表单会明确显示 CRM 未配置错误，不会提交数据。
+
+外部推广链接统一使用标准 UTM 参数，例如
+`?utm_source=feishu&utm_medium=referral&utm_campaign=launch`。官网会通过 Cookie
+保留并将这些 UTM 字段随表单提交给 CRM，不需要额外维护 `source` 参数。
+
 ## Build
 
 ```bash

--- a/src/app/LeadAttribution.tsx
+++ b/src/app/LeadAttribution.tsx
@@ -9,12 +9,7 @@ const LeadAttribution = () => {
       void import('@/lib/leadAttribution').then(
         ({ configureAttribution, reportAnonymousAttribution }) => {
           configureAttribution({
-            cookieDomain:
-              process.env.NEXT_PUBLIC_ATTRIBUTION_COOKIE_DOMAIN?.trim() || '.fastgpt.io',
-            storageMode:
-              process.env.NEXT_PUBLIC_ATTRIBUTION_STORAGE_MODE === 'localStorage'
-                ? 'localStorage'
-                : 'cookie'
+            cookieDomain: process.env.NEXT_PUBLIC_ATTRIBUTION_COOKIE_DOMAIN?.trim() || undefined
           });
           void reportAnonymousAttribution();
         }

--- a/src/app/[lang]/contact/page.tsx
+++ b/src/app/[lang]/contact/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next';
+import ContactPage from '@/components/contact/ContactPage';
+import { getContactCopy } from '@/components/contact/contactCopy';
+import { getAlternates } from '@/lib/seo';
+import { localeNames, normalizeLocale } from '@/lib/i18n';
+
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ lang: string }>;
+}): Promise<Metadata> {
+  const { lang } = await params;
+  const locale = normalizeLocale(lang);
+  const copy = getContactCopy(locale);
+  return {
+    title: `${copy.title} | FastGPT`,
+    description: copy.subtitle,
+    alternates: getAlternates(locale, '/contact')
+  };
+}
+
+export default async function LocalizedContactPage({
+  params
+}: {
+  params: Promise<{ lang: string }>;
+}) {
+  const { lang } = await params;
+  return <ContactPage locale={lang} />;
+}
+
+export function generateStaticParams() {
+  return Object.keys(localeNames).map((lang) => ({ lang }));
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next';
+import ContactPage from '@/components/contact/ContactPage';
+import { getContactCopy } from '@/components/contact/contactCopy';
+import { defaultLocale } from '@/lib/i18n';
+
+export function generateMetadata(): Metadata {
+  const copy = getContactCopy(defaultLocale);
+  const baseUrl = process.env.NEXT_PUBLIC_HOME_URL || 'https://fastgpt.io';
+  return {
+    title: `${copy.title} | FastGPT`,
+    description: copy.subtitle,
+    alternates: { canonical: `${baseUrl}/contact` }
+  };
+}
+
+export default function DefaultContactPage() {
+  return <ContactPage locale={defaultLocale} />;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import LeadAttribution from '@/app/LeadAttribution';
 import RybbitAnalytics from '@/app/RybbitAnalytics';
 import { ThemeProvider } from '@/components/ThemeProvider';
 import MotionProvider from '@/components/home/motion/MotionProvider';
+import ConsultationProvider from '@/components/contact/ConsultationProvider';
 import { siteConfig } from '@/config/site';
 import { cn } from '@/lib/utils';
 import { defaultLocale } from '@/lib/i18n';
@@ -76,7 +77,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           enableSystem={false}
           forcedTheme="dark"
         >
-          <MotionProvider>{children}</MotionProvider>
+          <MotionProvider>
+            <ConsultationProvider defaultLocale={defaultLocale}>{children}</ConsultationProvider>
+          </MotionProvider>
         </ThemeProvider>
         <GoogleAnalytics />
         <BaiDuAnalytics />

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -14,7 +14,7 @@ import { getComparisonPagesForLocale } from '@/content/competitor';
 export const dynamic = 'force-static';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const localizedPaths = ['', '/price'];
+  const localizedPaths = ['', '/price', '/contact'];
   const now = new Date();
   const entries: MetadataRoute.Sitemap = [];
   const seenUrls = new Set<string>();

--- a/src/components/contact/ConsultationProvider.tsx
+++ b/src/components/contact/ConsultationProvider.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+import { usePathname } from 'next/navigation';
+import ContactForm from '@/components/contact/ContactForm';
+import { getContactCopy } from '@/components/contact/contactCopy';
+import { getLocaleFromPathname, isContactHref } from '@/lib/consultation';
+
+type ConsultationProviderProps = {
+  children: ReactNode;
+  defaultLocale: string;
+};
+
+export default function ConsultationProvider({
+  children,
+  defaultLocale
+}: ConsultationProviderProps) {
+  const pathname = usePathname() || '/';
+  const locale = getLocaleFromPathname(pathname, defaultLocale);
+  const copy = getContactCopy(locale);
+  const [open, setOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    queueMicrotask(() => setMounted(true));
+  }, []);
+
+  useEffect(() => {
+    const handleConsultationClick = (event: MouseEvent) => {
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      ) {
+        return;
+      }
+      const target =
+        event.target instanceof Element
+          ? event.target.closest<HTMLAnchorElement>(
+              'a[data-consultation-link], a[href*="/contact"]'
+            )
+          : null;
+      if (
+        !target ||
+        !isContactHref(target.getAttribute('href') || target.href) ||
+        target.target === '_blank' ||
+        target.hasAttribute('download')
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      returnFocusRef.current =
+        document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      setOpen(true);
+    };
+
+    document.addEventListener('click', handleConsultationClick, true);
+    return () => document.removeEventListener('click', handleConsultationClick, true);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    closeButtonRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setOpen(false);
+        return;
+      }
+      if (event.key !== 'Tab' || !dialogRef.current) return;
+
+      const focusable = Array.from(
+        dialogRef.current.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])'
+        )
+      );
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+      returnFocusRef.current?.focus();
+    };
+  }, [open]);
+
+  const close = () => {
+    setOpen(false);
+  };
+
+  return (
+    <>
+      {children}
+      {mounted &&
+        open &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-[100] flex items-end justify-center bg-[#101828]/55 p-0 backdrop-blur-[2px] sm:items-center sm:p-6"
+            onMouseDown={(event) => {
+              if (event.target === event.currentTarget) close();
+            }}
+          >
+            <div
+              ref={dialogRef}
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="consultation-dialog-title"
+              className="flex max-h-[94dvh] w-full flex-col overflow-hidden rounded-t-lg bg-white shadow-[0_24px_80px_rgba(16,24,40,0.28)] sm:max-h-[min(90dvh,860px)] sm:max-w-[760px] sm:rounded-lg"
+            >
+              <header className="relative shrink-0 border-b border-[#eaecf0] bg-white px-5 py-5 pr-16 sm:px-8 sm:py-6 sm:pr-20">
+                <span className="mb-2 block text-[11px] font-semibold uppercase text-[#155eef]">
+                  {copy.eyebrow}
+                </span>
+                <h2
+                  id="consultation-dialog-title"
+                  className="m-0 text-[22px] font-semibold leading-8 text-[#101828] sm:text-[24px]"
+                >
+                  {copy.title}
+                </h2>
+                <p className="mt-1 max-w-[570px] text-[13px] leading-5 text-[#667085] sm:text-[14px] sm:leading-6">
+                  {copy.subtitle}
+                </p>
+                <button
+                  ref={closeButtonRef}
+                  type="button"
+                  onClick={close}
+                  aria-label={copy.close}
+                  title={copy.close}
+                  className="absolute right-4 top-4 inline-flex size-9 items-center justify-center rounded-md text-[#667085] transition-colors hover:bg-[#f2f4f7] hover:text-[#101828] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#155eef] sm:right-6 sm:top-6"
+                >
+                  <X size={19} strokeWidth={1.8} aria-hidden />
+                </button>
+              </header>
+              <div className="min-h-0 overflow-y-auto overscroll-contain">
+                <ContactForm
+                  locale={locale}
+                  variant="modal"
+                  onDone={close}
+                />
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -1,0 +1,409 @@
+'use client';
+
+import { FormEvent, useEffect, useRef, useState } from 'react';
+import { AlertTriangle, CheckCircle2, ChevronDown, LoaderCircle } from 'lucide-react';
+import {
+  getAttributionPayload,
+  getVisitorId,
+  reportAnonymousAttribution,
+  trackVisit
+} from '@/lib/leadAttribution';
+import {
+  CONTACT_OPTIONS,
+  INITIAL_CONTACT_FORM,
+  type ContactFormValues,
+  getContactCopy,
+  getContactOptionLabel
+} from '@/components/contact/contactCopy';
+
+type ContactFormProps = {
+  locale: string;
+  variant?: 'modal' | 'page';
+  onDone?: () => void;
+};
+
+const CRM_API_URL = process.env.NEXT_PUBLIC_CRM_API_URL?.trim().replace(/\/$/, '') || '';
+
+function FieldLabel({
+  children,
+  required,
+  requiredText,
+  optionalText
+}: {
+  children: string;
+  required?: boolean;
+  requiredText: string;
+  optionalText: string;
+}) {
+  return (
+    <span className="mb-2 flex items-center gap-1 text-[13px] font-medium leading-5 text-[#1d2939]">
+      {required && (
+        <span className="text-[15px] font-semibold leading-4 text-[#e5484d]" aria-hidden="true">
+          *
+        </span>
+      )}
+      {children}
+      {!required && (
+        <span aria-hidden="true" className="text-[11px] font-normal text-[#98a2b3]">
+          {optionalText}
+        </span>
+      )}
+      <span className="sr-only">{required ? requiredText : optionalText}</span>
+    </span>
+  );
+}
+
+function SelectField({
+  label,
+  name,
+  value,
+  options,
+  placeholder,
+  copy,
+  required,
+  fullWidth,
+  onChange
+}: {
+  label: string;
+  name: keyof ContactFormValues;
+  value: string;
+  options: readonly string[];
+  placeholder: string;
+  copy: ReturnType<typeof getContactCopy>;
+  required?: boolean;
+  fullWidth?: boolean;
+  onChange: (name: keyof ContactFormValues, value: string) => void;
+}) {
+  return (
+    <label className={`block min-w-0 ${fullWidth ? 'sm:col-span-2' : ''}`}>
+      <FieldLabel required={required} requiredText={copy.required} optionalText={copy.optional}>
+        {label}
+      </FieldLabel>
+      <span className="relative block">
+        <select
+          name={name}
+          value={value}
+          required={required}
+          onChange={(event) => onChange(name, event.target.value)}
+          className="h-11 w-full appearance-none rounded-md border border-[#d0d5dd] bg-white px-3 pr-10 text-[14px] text-[#101828] outline-none transition-colors focus:border-[#155eef] focus:ring-2 focus:ring-[#155eef]/15 disabled:cursor-not-allowed disabled:bg-[#f9fafb]"
+        >
+          <option value="">{placeholder}</option>
+          {options.map((option) => (
+            <option key={option} value={option}>
+              {getContactOptionLabel(copy, option)}
+            </option>
+          ))}
+        </select>
+        <ChevronDown
+          aria-hidden
+          size={16}
+          strokeWidth={1.8}
+          className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#667085]"
+        />
+      </span>
+    </label>
+  );
+}
+
+export default function ContactForm({
+  locale,
+  variant = 'page',
+  onDone
+}: ContactFormProps) {
+  const copy = getContactCopy(locale);
+  const formRef = useRef<HTMLFormElement>(null);
+  const [values, setValues] = useState<ContactFormValues>(INITIAL_CONTACT_FORM);
+  const [visitorId, setVisitorId] = useState('');
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success'>('idle');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    queueMicrotask(() => {
+      setVisitorId(getVisitorId());
+    });
+  }, []);
+
+  const updateValue = (name: keyof ContactFormValues, value: string) => {
+    setValues((current) => ({ ...current, [name]: value }));
+    if (error) setError('');
+  };
+
+  const reset = () => {
+    setValues(INITIAL_CONTACT_FORM);
+    setError('');
+    setStatus('idle');
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError('');
+
+    if (!CRM_API_URL) {
+      setError(copy.configErrorBody);
+      return;
+    }
+    const currentVisitorId = visitorId || getVisitorId();
+    if (!currentVisitorId) {
+      setError(copy.visitorError);
+      return;
+    }
+    if (!values.usedOpenSource) {
+      setError(copy.requiredError);
+      return;
+    }
+
+    const phoneDigits = values.phone.replace(/\D/g, '');
+    if (phoneDigits.length < 6 || phoneDigits.length > 20) {
+      setError(copy.phoneError);
+      return;
+    }
+    if (!formRef.current?.reportValidity()) return;
+
+    setStatus('submitting');
+    try {
+      trackVisit();
+      await reportAnonymousAttribution();
+      const attribution = getAttributionPayload();
+      const response = await fetch(`${CRM_API_URL}/contacts/submit`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: values.name.trim(),
+          phone: values.phone.trim(),
+          company: values.company.trim(),
+          position: values.position.trim(),
+          used_open_source: values.usedOpenSource,
+          consultation_topic: values.consultationTopic,
+          project_stage: values.projectStage,
+          budget: values.budget || null,
+          notes: values.notes.trim() || null,
+          locale,
+          ...attribution,
+          visitor_id: currentVisitorId
+        })
+      });
+
+      if (!response.ok) {
+        let detail = '';
+        try {
+          const data = (await response.json()) as { detail?: unknown; message?: unknown };
+          detail =
+            (typeof data.detail === 'string' && data.detail) ||
+            (typeof data.message === 'string' && data.message) ||
+            '';
+        } catch {
+          // Fall back to a localized message when the CRM does not return JSON.
+        }
+        throw new Error(
+          response.status === 429 ? copy.rateLimitError : detail || copy.genericError
+        );
+      }
+
+      setStatus('success');
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : copy.genericError);
+      setStatus('idle');
+    }
+  };
+
+  if (!CRM_API_URL) {
+    return (
+      <div
+        role="alert"
+        data-crm-config-error
+        className="flex min-h-[280px] flex-col items-start justify-center border-y border-[#fee4e2] bg-[#fffafa] px-5 py-10 sm:px-8"
+      >
+        <span className="mb-5 inline-flex size-10 items-center justify-center rounded-md border border-[#fecdca] bg-white text-[#d92d20]">
+          <AlertTriangle size={20} aria-hidden />
+        </span>
+        <h2 className="m-0 text-[20px] font-semibold leading-7 text-[#101828]">
+          {copy.configErrorTitle}
+        </h2>
+        <p className="mt-2 max-w-[520px] text-[14px] leading-6 text-[#667085]">
+          {copy.configErrorBody}
+        </p>
+      </div>
+    );
+  }
+
+  if (status === 'success') {
+    return (
+      <div
+        role="status"
+        className="flex min-h-[380px] flex-col items-center justify-center px-5 py-12 text-center sm:px-8"
+      >
+        <span className="mb-5 inline-flex size-12 items-center justify-center rounded-md bg-[#ecfdf3] text-[#079455]">
+          <CheckCircle2 size={26} strokeWidth={1.8} aria-hidden />
+        </span>
+        <h2 className="m-0 text-[22px] font-semibold leading-8 text-[#101828]">
+          {copy.successTitle}
+        </h2>
+        <p className="mt-2 max-w-[420px] text-[14px] leading-6 text-[#667085]">
+          {copy.successBody}
+        </p>
+        <div className="mt-7 flex flex-col-reverse gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={reset}
+            className="h-10 rounded-md border border-[#d0d5dd] bg-white px-4 text-[13px] font-medium text-[#344054] transition-colors hover:bg-[#f9fafb] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#155eef]"
+          >
+            {copy.submitAnother}
+          </button>
+          {onDone && (
+            <button
+              type="button"
+              onClick={onDone}
+              className="h-10 rounded-md bg-[#155eef] px-5 text-[13px] font-medium text-white transition-colors hover:bg-[#004eeb] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#155eef] focus-visible:ring-offset-2"
+            >
+              {copy.closeAfterSuccess}
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  const textInputClass =
+    'h-11 w-full rounded-md border border-[#d0d5dd] bg-white px-3 text-[14px] text-[#101828] outline-none placeholder:text-[#98a2b3] transition-colors focus:border-[#155eef] focus:ring-2 focus:ring-[#155eef]/15';
+
+  return (
+    <form ref={formRef} onSubmit={handleSubmit} className="px-5 pb-6 pt-5 sm:px-8 sm:pb-8">
+      <input type="hidden" name="visitor_id" value={visitorId} />
+      <div className="grid grid-cols-1 gap-x-5 gap-y-5 sm:grid-cols-2">
+        {(['name', 'phone', 'company', 'position'] as const).map((name) => (
+          <label key={name} className="block min-w-0">
+            <FieldLabel required requiredText={copy.required} optionalText={copy.optional}>
+              {copy.fields[name]}
+            </FieldLabel>
+            <input
+              name={name}
+              type={name === 'phone' ? 'tel' : 'text'}
+              inputMode={name === 'phone' ? 'tel' : undefined}
+              autoComplete={
+                name === 'name'
+                  ? 'name'
+                  : name === 'phone'
+                  ? 'tel'
+                  : name === 'company'
+                  ? 'organization'
+                  : 'organization-title'
+              }
+              value={values[name]}
+              required
+              maxLength={
+                name === 'phone' ? 30 : name === 'company' ? 200 : name === 'position' ? 100 : 120
+              }
+              onChange={(event) => updateValue(name, event.target.value)}
+              placeholder={copy.placeholders[name]}
+              className={textInputClass}
+            />
+          </label>
+        ))}
+
+        <SelectField
+          label={copy.fields.consultationTopic}
+          name="consultationTopic"
+          value={values.consultationTopic}
+          options={CONTACT_OPTIONS.consultationTopic}
+          placeholder={copy.selectPlaceholder}
+          copy={copy}
+          required
+          onChange={updateValue}
+        />
+        <fieldset className="min-w-0">
+          <legend>
+            <FieldLabel required requiredText={copy.required} optionalText={copy.optional}>
+              {copy.fields.usedOpenSource}
+            </FieldLabel>
+          </legend>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {CONTACT_OPTIONS.usedOpenSource.map((option) => {
+              const selected = values.usedOpenSource === option;
+              return (
+                <label
+                  key={option}
+                  className={`flex h-11 cursor-pointer items-center justify-start gap-2 rounded-md border px-3 text-[14px] font-medium transition-colors focus-within:ring-2 focus-within:ring-[#155eef]/20 focus-within:ring-offset-1 ${
+                    selected
+                      ? 'border-[#155eef] bg-[#eef4ff] text-[#155eef]'
+                      : 'border-[#d0d5dd] bg-white text-[#344054] hover:border-[#98a2b3] hover:bg-[#f9fafb]'
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="used_open_source"
+                    value={option}
+                    checked={selected}
+                    required
+                    onChange={() => updateValue('usedOpenSource', option)}
+                    className="sr-only"
+                  />
+                  <span
+                    aria-hidden="true"
+                    className={`flex size-4 shrink-0 items-center justify-center rounded-full border ${
+                      selected ? 'border-[#155eef]' : 'border-[#98a2b3]'
+                    }`}
+                  >
+                    {selected && <span className="size-2 rounded-full bg-[#155eef]" />}
+                  </span>
+                  {getContactOptionLabel(copy, option)}
+                </label>
+              );
+            })}
+          </div>
+        </fieldset>
+        <SelectField
+          label={copy.fields.projectStage}
+          name="projectStage"
+          value={values.projectStage}
+          options={CONTACT_OPTIONS.projectStage}
+          placeholder={copy.selectPlaceholder}
+          copy={copy}
+          required
+          onChange={updateValue}
+        />
+        <SelectField
+          label={copy.fields.budget}
+          name="budget"
+          value={values.budget}
+          options={CONTACT_OPTIONS.budget}
+          placeholder={copy.selectPlaceholder}
+          copy={copy}
+          onChange={updateValue}
+        />
+        <label className="block min-w-0 sm:col-span-2">
+          <FieldLabel requiredText={copy.required} optionalText={copy.optional}>
+            {copy.fields.notes}
+          </FieldLabel>
+          <textarea
+            name="notes"
+            value={values.notes}
+            maxLength={1000}
+            rows={variant === 'modal' ? 3 : 4}
+            onChange={(event) => updateValue('notes', event.target.value)}
+            placeholder={copy.placeholders.notes}
+            className="w-full resize-y rounded-md border border-[#d0d5dd] bg-white px-3 py-2.5 text-[14px] leading-6 text-[#101828] outline-none placeholder:text-[#98a2b3] transition-colors focus:border-[#155eef] focus:ring-2 focus:ring-[#155eef]/15"
+          />
+        </label>
+      </div>
+
+      <button
+        type="submit"
+        disabled={status === 'submitting'}
+        className="mt-6 inline-flex h-11 w-full items-center justify-center gap-2 rounded-md bg-[#155eef] px-5 text-[14px] font-medium text-white transition-colors hover:bg-[#004eeb] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#155eef] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:bg-[#84adff]"
+      >
+        {status === 'submitting' && <LoaderCircle className="animate-spin" size={17} aria-hidden />}
+        {status === 'submitting' ? copy.submitting : copy.submit}
+      </button>
+
+      {error && (
+        <div
+          role="alert"
+          className="mt-3 flex items-start gap-2 rounded-md border border-[#fecdca] bg-[#fffbfa] px-3 py-2.5 text-[13px] leading-5 text-[#b42318]"
+        >
+          <AlertTriangle className="mt-0.5 shrink-0" size={15} aria-hidden />
+          <span>{error}</span>
+        </div>
+      )}
+    </form>
+  );
+}

--- a/src/components/contact/ContactPage.tsx
+++ b/src/components/contact/ContactPage.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import ContactForm from '@/components/contact/ContactForm';
+import { getContactCopy } from '@/components/contact/contactCopy';
+import { normalizeLocale } from '@/lib/locales';
+
+export default function ContactPage({ locale }: { locale: string }) {
+  const router = useRouter();
+  const normalizedLocale = normalizeLocale(locale);
+  const copy = getContactCopy(normalizedLocale);
+  const homeHref = `/${normalizedLocale}`;
+
+  return (
+    <div className="home min-h-screen bg-white text-[#101828]">
+      <header className="border-b border-[#eaecf0] bg-white">
+        <div className="mx-auto flex h-16 max-w-[1180px] items-center justify-between px-5 sm:px-8">
+          <Link href={homeHref} className="flex items-center gap-2" aria-label="FastGPT Home">
+            <Image src="/logo-nav.svg" width={24} height={24} alt="" draggable={false} />
+            <span className="text-[17px] font-semibold text-[#101828]">FastGPT</span>
+          </Link>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="inline-flex items-center gap-2 text-[13px] font-medium text-[#475467] transition-colors hover:text-[#101828] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#155eef]"
+          >
+            <ArrowLeft size={15} strokeWidth={1.8} aria-hidden />
+            {copy.back}
+          </button>
+        </div>
+      </header>
+
+      <main className="relative overflow-hidden bg-[#f8fafc] px-5 py-10 sm:px-8 sm:py-14 lg:py-16">
+        <div className="absolute inset-y-0 left-0 hidden w-[7px] bg-[#155eef] sm:block" aria-hidden />
+        <div className="mx-auto max-w-[820px]">
+          <div className="mb-8 max-w-[680px] sm:mb-10">
+            <span className="mb-3 block text-[11px] font-semibold uppercase text-[#155eef]">
+              {copy.eyebrow}
+            </span>
+            <h1 className="m-0 text-[30px] font-semibold leading-[38px] text-[#101828] sm:text-[38px] sm:leading-[48px]">
+              {copy.title}
+            </h1>
+            <p className="mt-3 text-[15px] leading-6 text-[#667085] sm:text-[16px] sm:leading-7">
+              {copy.subtitle}
+            </p>
+          </div>
+
+          <section
+            aria-label={copy.title}
+            className="overflow-hidden rounded-lg border border-[#dfe3e8] bg-white shadow-[0_8px_30px_rgba(16,24,40,0.06)]"
+          >
+            <ContactForm locale={normalizedLocale} />
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/components/contact/contactCopy.ts
+++ b/src/components/contact/contactCopy.ts
@@ -1,0 +1,212 @@
+import type { LocaleCode } from '@/lib/locales';
+
+export type ContactFormValues = {
+  name: string;
+  phone: string;
+  company: string;
+  position: string;
+  usedOpenSource: string;
+  consultationTopic: string;
+  projectStage: string;
+  budget: string;
+  notes: string;
+};
+
+export const INITIAL_CONTACT_FORM: ContactFormValues = {
+  name: '',
+  phone: '',
+  company: '',
+  position: '',
+  usedOpenSource: '',
+  consultationTopic: '',
+  projectStage: '',
+  budget: '',
+  notes: ''
+};
+
+export const CONTACT_OPTIONS = {
+  usedOpenSource: ['是', '否'],
+  consultationTopic: ['私有化部署', 'SaaS 版', '渠道合作', '其他'],
+  projectStage: ['调研阶段/竞品对比', '立项阶段/测试使用', '采购阶段/最终决策'],
+  budget: ['0-3 万元', '3-10 万元', '10-30 万元', '30-100 万元', '100 万元以上']
+} as const;
+
+type ContactCopy = {
+  title: string;
+  subtitle: string;
+  eyebrow: string;
+  close: string;
+  back: string;
+  required: string;
+  optional: string;
+  fields: Record<keyof ContactFormValues, string>;
+  placeholders: Partial<Record<keyof ContactFormValues, string>>;
+  selectPlaceholder: string;
+  options: Record<string, string>;
+  submit: string;
+  submitting: string;
+  successTitle: string;
+  successBody: string;
+  closeAfterSuccess: string;
+  submitAnother: string;
+  configErrorTitle: string;
+  configErrorBody: string;
+  visitorError: string;
+  genericError: string;
+  rateLimitError: string;
+  phoneError: string;
+  requiredError: string;
+};
+
+const zh: ContactCopy = {
+  title: 'FastGPT 商务咨询',
+  subtitle: '请留下项目情况和联系方式，FastGPT 商务团队会尽快与您联系。',
+  eyebrow: '企业服务',
+  close: '关闭',
+  back: '返回',
+  required: '必填',
+  optional: '选填',
+  fields: {
+    name: '姓名',
+    phone: '手机号',
+    company: '公司名称',
+    position: '职位',
+    usedOpenSource: '是否使用过开源版',
+    consultationTopic: '想咨询的内容',
+    projectStage: '项目进度',
+    budget: '项目预算',
+    notes: '补充说明'
+  },
+  placeholders: {
+    name: '请输入姓名',
+    phone: '请输入手机号',
+    company: '请输入公司名称',
+    position: '请输入职位',
+    notes: '可补充使用场景、部署规模或其他需求'
+  },
+  selectPlaceholder: '请选择',
+  options: {},
+  submit: '提交咨询',
+  submitting: '正在提交',
+  successTitle: '咨询已提交',
+  successBody: '我们已收到您的信息，商务团队会尽快与您联系。',
+  closeAfterSuccess: '完成',
+  submitAnother: '再提交一份',
+  configErrorTitle: '商务咨询暂不可用',
+  configErrorBody: 'CRM 服务尚未配置，请联系网站管理员。',
+  visitorError: '无法获取 CRM 访客标识，请允许浏览器使用本地存储后重试。',
+  genericError: '提交失败，请稍后重试。',
+  rateLimitError: '提交过于频繁，请稍后再试。',
+  phoneError: '请输入有效的手机号。',
+  requiredError: '请完整填写所有必填项。'
+};
+
+const en: ContactCopy = {
+  title: 'Contact FastGPT Sales',
+  subtitle: 'Tell us about your project and our sales team will get back to you shortly.',
+  eyebrow: 'Enterprise services',
+  close: 'Close',
+  back: 'Back',
+  required: 'Required',
+  optional: 'Optional',
+  fields: {
+    name: 'Name',
+    phone: 'Phone number',
+    company: 'Company',
+    position: 'Job title',
+    usedOpenSource: 'Have you used the open-source edition?',
+    consultationTopic: 'What would you like to discuss?',
+    projectStage: 'Project stage',
+    budget: 'Project budget',
+    notes: 'Additional details'
+  },
+  placeholders: {
+    name: 'Your name',
+    phone: 'Your phone number',
+    company: 'Company name',
+    position: 'Your role',
+    notes: 'Use case, deployment scale, or other requirements'
+  },
+  selectPlaceholder: 'Select an option',
+  options: {
+    是: 'Yes',
+    否: 'No',
+    私有化部署: 'Private deployment',
+    'SaaS 版': 'SaaS edition',
+    渠道合作: 'Channel partnership',
+    其他: 'Other',
+    '调研阶段/竞品对比': 'Researching / comparing products',
+    '立项阶段/测试使用': 'Planning / testing',
+    '采购阶段/最终决策': 'Procurement / final decision',
+    '0-3 万元': 'CNY 0-30,000',
+    '3-10 万元': 'CNY 30,000-100,000',
+    '10-30 万元': 'CNY 100,000-300,000',
+    '30-100 万元': 'CNY 300,000-1,000,000',
+    '100 万元以上': 'Above CNY 1,000,000'
+  },
+  submit: 'Send inquiry',
+  submitting: 'Sending',
+  successTitle: 'Inquiry sent',
+  successBody: 'We have received your information. Our sales team will contact you shortly.',
+  closeAfterSuccess: 'Done',
+  submitAnother: 'Send another inquiry',
+  configErrorTitle: 'Sales inquiries are unavailable',
+  configErrorBody:
+    'The CRM service has not been configured. Please contact the site administrator.',
+  visitorError:
+    'We could not create your CRM visitor ID. Allow local browser storage and try again.',
+  genericError: 'Your inquiry could not be sent. Please try again later.',
+  rateLimitError: 'Too many submissions. Please try again later.',
+  phoneError: 'Enter a valid phone number.',
+  requiredError: 'Complete all required fields.'
+};
+
+const zhHant: ContactCopy = {
+  ...zh,
+  title: 'FastGPT 商務諮詢',
+  subtitle: '請留下專案情況和聯絡方式，FastGPT 商務團隊會盡快與您聯絡。',
+  eyebrow: '企業服務',
+  close: '關閉',
+  back: '返回',
+  required: '必填',
+  optional: '選填',
+  fields: {
+    name: '姓名',
+    phone: '手機號碼',
+    company: '公司名稱',
+    position: '職位',
+    usedOpenSource: '是否使用過開源版',
+    consultationTopic: '想諮詢的內容',
+    projectStage: '專案進度',
+    budget: '專案預算',
+    notes: '補充說明'
+  },
+  selectPlaceholder: '請選擇',
+  submit: '提交諮詢',
+  submitting: '正在提交',
+  successTitle: '諮詢已提交',
+  successBody: '我們已收到您的資訊，商務團隊會盡快與您聯絡。',
+  closeAfterSuccess: '完成',
+  submitAnother: '再提交一份',
+  configErrorTitle: '商務諮詢暫不可用',
+  configErrorBody: 'CRM 服務尚未配置，請聯絡網站管理員。',
+  visitorError: '無法取得 CRM 訪客識別碼，請允許瀏覽器使用本機儲存後重試。',
+  genericError: '提交失敗，請稍後重試。',
+  rateLimitError: '提交過於頻繁，請稍後再試。',
+  phoneError: '請輸入有效的手機號碼。',
+  requiredError: '請完整填寫所有必填項。'
+};
+
+const contactCopy: Partial<Record<LocaleCode, ContactCopy>> = {
+  zh,
+  'zh-hant': zhHant,
+  en
+};
+
+export function getContactCopy(locale: string): ContactCopy {
+  return contactCopy[locale as LocaleCode] || en;
+}
+
+export function getContactOptionLabel(copy: ContactCopy, value: string): string {
+  return copy.options[value] || value;
+}

--- a/src/components/enterprise/ECTA.tsx
+++ b/src/components/enterprise/ECTA.tsx
@@ -1,8 +1,9 @@
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { FaArrowRight } from "react-icons/fa6";
-import { NormalSection } from ".";
-import { siteConfig } from "@/config/site";
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { FaArrowRight } from 'react-icons/fa6';
+import { NormalSection } from '.';
+import { siteConfig } from '@/config/site';
+import { isContactHref } from '@/lib/consultation';
 
 interface Props {
   locale: any;
@@ -16,9 +17,10 @@ const ECTA = ({ locale }: Props) => {
     <NormalSection id="ECTA" title={ctaLocale.title} description={ctaLocale.description}>
       <Link
         href={commercial}
-        rel="noopener noreferrer nofollow"
         className="my-8 flex justify-center"
-        target="_blank"
+        {...(isContactHref(commercial)
+          ? { 'data-consultation-link': 'true' }
+          : { target: '_blank', rel: 'noopener noreferrer nofollow' })}
       >
         <Button
           variant="default"
@@ -26,7 +28,7 @@ const ECTA = ({ locale }: Props) => {
           aria-label="Get Boilerplate"
         >
           {ctaLocale.link}
-          <FaArrowRight className='text-base' />
+          <FaArrowRight className="text-base" />
         </Button>
       </Link>
     </NormalSection>

--- a/src/components/header/CTAButton.tsx
+++ b/src/components/header/CTAButton.tsx
@@ -12,36 +12,35 @@ const CTAButton = ({ locale }: { locale: any }) => {
 
   return (
     <div className="flex items-center gap-6">
-      <Link
-        href="https://fael3z0zfze.feishu.cn/share/base/form/shrcnjJWtKqjOI9NbQTzhNyzljc?prefill_S=C2&hide_S=1"
-        target="_blank"
-        rel="noopener noreferrer nofollow"
-        {...rybbitClickAttrs(RYBBIT_EVENTS.businessConsultClick, 'enterprise_footer_consult')}
-      >
-        <Button
-          variant="default"
-          className="flex items-center gap-3 bg-[#B9DFFF] hover:bg-[#91C2EB] text-[#3941DD] px-6 py-4 text-sm ask-btn"
-          aria-label="Get Boilerplate"
-        >
-          {locale.askTitle}
-        </Button>
-      </Link>
       <div className="inline-block rotating-border-button">
         <Link
-          href={getLinkConfig()}
-          rel="noopener noreferrer nofollow"
-          {...rybbitClickAttrs(RYBBIT_EVENTS.cloudServiceClick, 'enterprise_footer_trial')}
+          href="/contact"
+          data-consultation-link="true"
+          {...rybbitClickAttrs(RYBBIT_EVENTS.businessConsultClick, 'enterprise_footer_consult')}
         >
           <Button
             variant="default"
             className="flex items-center gap-3 bg-[#B9DFFF] hover:bg-[#91C2EB] text-[#3941DD] px-6 py-4 text-sm start-btn"
             aria-label="Get Boilerplate"
           >
-            {locale.title}
+            {locale.askTitle}
             {/* <FaArrowRight className='text-base' /> */}
           </Button>
         </Link>
       </div>
+      <Link
+        href={getLinkConfig()}
+        rel="noopener noreferrer nofollow"
+        {...rybbitClickAttrs(RYBBIT_EVENTS.cloudServiceClick, 'enterprise_footer_trial')}
+      >
+        <Button
+          variant="default"
+          className="flex items-center gap-3 bg-[#B9DFFF] hover:bg-[#91C2EB] text-[#3941DD] px-6 py-4 text-sm ask-btn"
+          aria-label="Get Boilerplate"
+        >
+          {locale.title}
+        </Button>
+      </Link>
     </div>
   );
 };

--- a/src/components/home/CTA.tsx
+++ b/src/components/home/CTA.tsx
@@ -93,6 +93,17 @@ export default function CTA({ t }: { t: CTAT }) {
                 className="flex flex-col md:flex-row items-stretch md:items-center gap-3 md:gap-8 w-full"
               >
                 <m.a
+                  href={CONSULT_URL}
+                  data-consultation-link="true"
+                  {...rybbitClickAttrs(RYBBIT_EVENTS.businessConsultClick, 'home_bottom_consult')}
+                  whileHover={{ scale: 1.04 }}
+                  whileTap={{ scale: 0.97 }}
+                  aria-label={t.consult}
+                  className="w-full md:w-auto md:flex-initial inline-flex items-center justify-center h-[44px] md:h-11 px-6 md:px-8 rounded-[99px] text-[14px] md:text-[16px] font-medium leading-[20px] tracking-[-0.12px] bg-btn-dark border border-btn-border text-white transition-opacity hover:opacity-90"
+                >
+                  {t.consult}
+                </m.a>
+                <m.a
                   href={startUrl}
                   rel="noopener noreferrer nofollow"
                   {...rybbitClickAttrs(RYBBIT_EVENTS.cloudServiceClick, 'home_bottom_trial')}
@@ -102,18 +113,6 @@ export default function CTA({ t }: { t: CTAT }) {
                   className="w-full md:w-auto md:flex-initial inline-flex items-center justify-center h-[44px] md:h-11 px-6 md:px-8 rounded-[99px] text-[14px] md:text-[16px] font-semibold leading-[1.5em] bg-btn-light-bg border border-btn-light-border text-[#3d3d3d] transition-colors hover:bg-white/80"
                 >
                   {t.trial}
-                </m.a>
-                <m.a
-                  href={CONSULT_URL}
-                  target="_blank"
-                  rel="noopener noreferrer nofollow"
-                  {...rybbitClickAttrs(RYBBIT_EVENTS.businessConsultClick, 'home_bottom_consult')}
-                  whileHover={{ scale: 1.04 }}
-                  whileTap={{ scale: 0.97 }}
-                  aria-label={t.consult}
-                  className="w-full md:w-auto md:flex-initial inline-flex items-center justify-center h-[44px] md:h-11 px-6 md:px-8 rounded-[99px] text-[14px] md:text-[16px] font-medium leading-[20px] tracking-[-0.12px] bg-btn-dark border border-btn-border text-white transition-opacity hover:opacity-90"
-                >
-                  {t.consult}
                 </m.a>
               </m.div>
             </div>

--- a/src/components/home/CaseStudies.tsx
+++ b/src/components/home/CaseStudies.tsx
@@ -316,8 +316,7 @@ function CaseCard({ data, learnMore }: { data: CaseStudy; learnMore: string }) {
 
         <a
           href={CONSULT_URL}
-          target="_blank"
-          rel="noopener noreferrer nofollow"
+          data-consultation-link="true"
           {...rybbitClickAttrs(RYBBIT_EVENTS.businessConsultClick, 'home_case_study_consult', {
             case: data.key
           })}

--- a/src/components/home/Footer.tsx
+++ b/src/components/home/Footer.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { siteConfig } from '@/config/site';
 import CloudEntryLink from '@/components/home/CloudEntryLink';
 import { RYBBIT_EVENTS, rybbitClickAttrs } from '@/lib/rybbitEvents';
+import { isContactHref } from '@/lib/consultation';
 
 type ColumnLink = { label: string; href: string; external?: boolean; cloudEntrySource?: string };
 type Column = { title: string; width: number; items: (ColumnLink | { label: string })[] };
@@ -36,11 +37,19 @@ function buildColumns(t: FooterT['columns']): Column[] {
         },
         {
           label: t.service.items.private,
-          href: 'https://fael3z0zfze.feishu.cn/share/base/form/shrcnjJWtKqjOI9NbQTzhNyzljc?hide_S=1&prefill_S=C2',
+          href: '/contact',
+          external: false
+        },
+        {
+          label: t.service.items.community,
+          href: 'https://github.com/labring/FastGPT',
           external: true
         },
-        { label: t.service.items.community, href: 'https://github.com/labring/FastGPT', external: true },
-        { label: t.service.items.docs, href: 'https://doc.fastgpt.io/docs/introduction', external: true }
+        {
+          label: t.service.items.docs,
+          href: 'https://doc.fastgpt.io/docs/introduction',
+          external: true
+        }
       ]
     },
     {
@@ -57,7 +66,11 @@ function buildColumns(t: FooterT['columns']): Column[] {
       items: [
         { label: t.more.email },
         { label: t.more.lanqiao, href: 'https://www.lanqiao.cn/courses/6666', external: true },
-        { label: t.more.book, href: 'https://item.m.jd.com/product/10204687656446.html', external: true }
+        {
+          label: t.more.book,
+          href: 'https://item.m.jd.com/product/10204687656446.html',
+          external: true
+        }
       ]
     }
   ];
@@ -105,7 +118,7 @@ const linkStyle = {
   fontSize: 16,
   fontWeight: 400,
   lineHeight: '22px',
-  letterSpacing: '-0.01em',
+  letterSpacing: '-0.01em'
 } as const;
 
 const headingStyle = {
@@ -180,11 +193,16 @@ export default function Footer({ t }: { t: FooterT }) {
                 Mobile: link cols and QRs all stack vertically (no flex-wrap). */}
             <div className="flex flex-col w-full lg:w-auto" style={{ rowGap: 32 }}>
               {/* 3 link columns — vertical on mobile, row on md+ */}
-              <div className="flex flex-col md:flex-row md:flex-wrap" style={{ columnGap: 10, rowGap: 24 }}>
+              <div
+                className="flex flex-col md:flex-row md:flex-wrap"
+                style={{ columnGap: 10, rowGap: 24 }}
+              >
                 {columns.map((col) => (
                   <div
                     key={col.title}
-                    className={`flex flex-col w-full ${col.width === 220 ? 'md:w-[220px]' : 'md:w-[150px]'}`}
+                    className={`flex flex-col w-full ${
+                      col.width === 220 ? 'md:w-[220px]' : 'md:w-[150px]'
+                    }`}
                     style={{ rowGap: 10, alignItems: 'flex-start' }}
                   >
                     <h2 style={{ ...headingStyle, margin: 0, textAlign: 'left', width: '100%' }}>
@@ -216,12 +234,17 @@ export default function Footer({ t }: { t: FooterT }) {
                             {...(item.external
                               ? { target: '_blank', rel: 'noopener noreferrer nofollow' }
                               : {})}
-                            {...(item.href.includes('feishu.cn')
-                              ? rybbitClickAttrs(RYBBIT_EVENTS.businessConsultClick, 'footer_private_deploy')
+                            {...(isContactHref(item.href) || item.href.includes('feishu.cn')
+                              ? rybbitClickAttrs(
+                                  RYBBIT_EVENTS.businessConsultClick,
+                                  'footer_private_deploy'
+                                )
+                              : {})}
+                            {...(isContactHref(item.href)
+                              ? { 'data-consultation-link': 'true' }
                               : {})}
                             className="hover:text-black  text-ink-sub"
                             style={{ ...linkStyle, textAlign: 'left' }}
-
                           >
                             {item.label}
                           </a>
@@ -241,7 +264,10 @@ export default function Footer({ t }: { t: FooterT }) {
               </div>
 
               {/* QR row — vertical on mobile, row on md+ */}
-              <div className="flex flex-col md:flex-row md:flex-wrap" style={{ columnGap: 10, rowGap: 16 }}>
+              <div
+                className="flex flex-col md:flex-row md:flex-wrap"
+                style={{ columnGap: 10, rowGap: 16 }}
+              >
                 {qrs.map((q) => (
                   <div
                     key={q.label}
@@ -284,7 +310,10 @@ export default function Footer({ t }: { t: FooterT }) {
             className="flex flex-col items-center md:flex-row md:items-center md:justify-between w-full"
             style={{ rowGap: 16 }}
           >
-            <div className="flex flex-wrap justify-center md:justify-start items-center text-center md:text-left" style={{ columnGap: 24, rowGap: 8 }}>
+            <div
+              className="flex flex-wrap justify-center md:justify-start items-center text-center md:text-left"
+              style={{ columnGap: 24, rowGap: 8 }}
+            >
               <a
                 href="https://github.com/labring/FastGPT"
                 target="_blank"

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -184,8 +184,7 @@ export default function Hero({ stars: initialStars, locale, t, children }: HeroP
             >
               <m.a
                 href={CONSULT_URL}
-                target="_blank"
-                rel="noopener noreferrer nofollow"
+                data-consultation-link="true"
                 {...rybbitClickAttrs(RYBBIT_EVENTS.businessConsultClick, 'home_hero_consult')}
                 whileHover={{ scale: 1.04 }}
                 whileTap={{ scale: 0.97 }}

--- a/src/components/home/HomeLayoutSwitcher.tsx
+++ b/src/components/home/HomeLayoutSwitcher.tsx
@@ -18,7 +18,8 @@ export default function HomeLayoutSwitcher({ dict, children }: HomeLayoutSwitche
   const isHome = /^\/([a-z]{2,3}(?:-[A-Za-z]{2,4})?)?$/.test(pathname);
   const isTechArticle =
     /\/(?:api|dataset|deploy|integration|node|troubleshoot|tutorial)\/[^/]+$/.test(pathname);
-  const isSelfContained = /\/faq|\/price|\/tech-center|\/compare/.test(pathname) || isTechArticle;
+  const isSelfContained =
+    /\/faq|\/price|\/tech-center|\/compare|\/contact/.test(pathname) || isTechArticle;
 
   if (isHome || isSelfContained) {
     return <>{children}</>;

--- a/src/components/home/Navbar.tsx
+++ b/src/components/home/Navbar.tsx
@@ -213,6 +213,15 @@ export default function Navbar({
               <LangSwitcher iconOnly locale={lang} />
             </div>
             <a
+              href={CONSULT_URL}
+              data-consultation-link="true"
+              {...rybbitClickAttrs(RYBBIT_EVENTS.businessConsultClick, 'home_nav_consult')}
+              aria-label={t.consult}
+              className="px-4 py-1.5 rounded-full text-[12px] font-medium text-white bg-btn-dark hover:opacity-90 transition-opacity"
+            >
+              {t.consult}
+            </a>
+            <a
               href={desktopStartUrl}
               rel="noopener noreferrer nofollow"
               {...rybbitClickAttrs(RYBBIT_EVENTS.cloudServiceClick, 'home_nav_trial')}
@@ -221,23 +230,12 @@ export default function Navbar({
             >
               {t.trial}
             </a>
-            <a
-              href={CONSULT_URL}
-              target="_blank"
-              rel="noopener noreferrer nofollow"
-              {...rybbitClickAttrs(RYBBIT_EVENTS.businessConsultClick, 'home_nav_consult')}
-              aria-label={t.consult}
-              className="px-4 py-1.5 rounded-full text-[12px] font-medium text-white bg-btn-dark hover:opacity-90 transition-opacity"
-            >
-              {t.consult}
-            </a>
           </div>
 
           <div className="flex items-center gap-3 md:hidden">
             <a
               href={CONSULT_URL}
-              target="_blank"
-              rel="noopener noreferrer nofollow"
+              data-consultation-link="true"
               {...rybbitClickAttrs(RYBBIT_EVENTS.businessConsultClick, 'home_nav_mobile_consult')}
               aria-label={t.consult}
               className={`px-4 py-1.5 rounded-full text-[12px] font-medium text-white bg-btn-dark transition-opacity duration-300 ${
@@ -342,6 +340,15 @@ export default function Navbar({
 
             <div className="flex flex-col gap-3 mt-6 pt-6 border-t border-hairline-soft">
               <a
+                href={CONSULT_URL}
+                data-consultation-link="true"
+                {...rybbitClickAttrs(RYBBIT_EVENTS.businessConsultClick, 'home_nav_mobile_menu_consult')}
+                className="h-10 inline-flex items-center justify-center rounded-full text-[13px] font-medium text-white bg-btn-dark"
+                onClick={() => setMobileOpen(false)}
+              >
+                {t.consult}
+              </a>
+              <a
                 href={mobileStartUrl}
                 rel="noopener noreferrer nofollow"
                 {...rybbitClickAttrs(RYBBIT_EVENTS.cloudServiceClick, 'home_nav_mobile_trial')}
@@ -349,19 +356,6 @@ export default function Navbar({
                 onClick={() => setMobileOpen(false)}
               >
                 {t.trial}
-              </a>
-              <a
-                href={CONSULT_URL}
-                target="_blank"
-                rel="noopener noreferrer nofollow"
-                {...rybbitClickAttrs(
-                  RYBBIT_EVENTS.businessConsultClick,
-                  'home_nav_mobile_menu_consult'
-                )}
-                className="h-10 inline-flex items-center justify-center rounded-full text-[13px] font-medium text-white bg-btn-dark"
-                onClick={() => setMobileOpen(false)}
-              >
-                {t.consult}
               </a>
             </div>
           </div>

--- a/src/components/home/Solutions.tsx
+++ b/src/components/home/Solutions.tsx
@@ -173,8 +173,7 @@ export default function Solutions({ t, locale }: { t: SolutionsT; locale: string
                 </div>
                 <a
                   href={CONSULT_URL}
-                  target="_blank"
-                  rel="noopener noreferrer nofollow"
+                  data-consultation-link="true"
                   {...rybbitClickAttrs(RYBBIT_EVENTS.businessConsultClick, 'home_solutions_consult', {
                     solution: current.key
                   })}

--- a/src/components/home/hooks/useStartUrl.ts
+++ b/src/components/home/hooks/useStartUrl.ts
@@ -16,5 +16,4 @@ export function useStartUrl(targetUrl?: string): string {
   return url;
 }
 
-export const CONSULT_URL =
-  'https://fael3z0zfze.feishu.cn/share/base/form/shrcnjJWtKqjOI9NbQTzhNyzljc?prefill_S=C2&hide_S=1';
+export const CONSULT_URL = '/contact';

--- a/src/components/price/PPlan.tsx
+++ b/src/components/price/PPlan.tsx
@@ -6,18 +6,13 @@ import Check from '@/components/icons/check';
 import { PRICE_PLANS_CLOUD, PRICE_PLANS_SELF, PRICE_PLANS_SELF_BUTTON_MAP } from '@/config/price';
 import Link from 'next/link';
 import { siteConfig } from '@/config/site';
+import { isContactHref } from '@/lib/consultation';
 import { useStartUrl } from '@/components/home/hooks/useStartUrl';
 import { RYBBIT_EVENTS, rybbitClickAttrs } from '@/lib/rybbitEvents';
 
 type Key = 'cloud' | 'self';
 
-function CloudPlanLink({
-  source,
-  children
-}: {
-  source: string;
-  children: React.ReactNode;
-}) {
+function CloudPlanLink({ source, children }: { source: string; children: React.ReactNode }) {
   const href = useStartUrl();
 
   return (
@@ -225,8 +220,13 @@ export default function PPlan({ langName, locale }: { langName: string; locale: 
                 ) : (
                   <Link
                     href={siteConfig.customPlanUrl}
-                    target="_blank"
                     className="mt-auto pt-4"
+                    {...(isContactHref(siteConfig.customPlanUrl)
+                      ? {}
+                      : { target: '_blank', rel: 'noopener noreferrer nofollow' })}
+                    {...(isContactHref(siteConfig.customPlanUrl)
+                      ? { 'data-consultation-link': 'true' }
+                      : {})}
                     {...rybbitClickAttrs(RYBBIT_EVENTS.businessConsultClick, 'price_cloud_custom')}
                   >
                     <button
@@ -309,9 +309,11 @@ export default function PPlan({ langName, locale }: { langName: string; locale: 
 
                 <Link
                   href={buttonConfig.href}
-                  target="_blank"
+                  {...(isContactHref(buttonConfig.href)
+                    ? { 'data-consultation-link': 'true' }
+                    : { target: '_blank', rel: 'noopener noreferrer nofollow' })}
                   className="mt-auto pt-4"
-                  {...(buttonConfig.href.includes('feishu.cn')
+                  {...(isContactHref(buttonConfig.href) || buttonConfig.href.includes('feishu.cn')
                     ? rybbitClickAttrs(RYBBIT_EVENTS.businessConsultClick, `price_self_${item.key}`)
                     : {})}
                 >

--- a/src/config/price.ts
+++ b/src/config/price.ts
@@ -973,6 +973,6 @@ export const PRICE_PLANS_SELF_BUTTON_MAP: {
     th: 'ติดต่อฝ่ายขาย',
     id: 'Hubungi Sales',
     ms: 'Hubungi Jualan',
-    href: 'https://fael3z0zfze.feishu.cn/share/base/form/shrcnjJWtKqjOI9NbQTzhNyzljc?prefill_S=H1&hide_S=1'
+    href: '/contact'
   }
 } as const;

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -16,7 +16,7 @@ const baseSiteConfig = {
   userUrl: process.env.NEXT_PUBLIC_USER_URL || 'https://cloud.fastgpt.io',
   customPlanUrl:
     process.env.NEXT_PUBLIC_CUSTOM_PLAN_URL ||
-    'https://fael3z0zfze.feishu.cn/share/base/form/shrcnjJWtKqjOI9NbQTzhNyzljc?prefill_S=C1&hide_S=1',
+    '/contact',
   metadataBase: currentSiteBaseUrl,
   keywords: [
     'rag',
@@ -39,8 +39,7 @@ const baseSiteConfig = {
     'enterprise knowledge base'
   ],
   // commercial: 'https://doc.fastgpt.io/docs/commercial/intro/',
-  commercial:
-    'https://fael3z0zfze.feishu.cn/share/base/form/shrcnjJWtKqjOI9NbQTzhNyzljc?prefill_S=G1&hide_S=1',
+  commercial: '/contact',
   authors: [
     {
       name: 'labring',

--- a/src/lib/attribution/config.ts
+++ b/src/lib/attribution/config.ts
@@ -1,16 +1,10 @@
-import type {
-  AttributionAdapterOptions,
-  AttributionStorageMode
-} from '@/lib/attribution/storage/adapter';
+import type { AttributionAdapterOptions } from '@/lib/attribution/storage/adapter';
 
 export interface AttributionConfiguration {
   cookieDomain?: string;
-  storageMode?: AttributionStorageMode;
 }
 
-let attributionConfiguration: AttributionConfiguration = {
-  storageMode: 'cookie'
-};
+let attributionConfiguration: AttributionConfiguration = {};
 
 export function configureAttribution(options: AttributionConfiguration = {}): void {
   attributionConfiguration = { ...attributionConfiguration, ...options };
@@ -20,14 +14,9 @@ export function getConfiguredCookieDomain(): string | undefined {
   return attributionConfiguration.cookieDomain;
 }
 
-function resolveStorageMode(): AttributionStorageMode {
-  return attributionConfiguration.storageMode ?? 'cookie';
-}
-
 export function getStorageOptions(): AttributionAdapterOptions {
   return {
     configuredDomain: attributionConfiguration.cookieDomain,
-    currentHostname: typeof window === 'undefined' ? undefined : window.location.hostname,
-    storageMode: resolveStorageMode()
+    currentHostname: typeof window === 'undefined' ? undefined : window.location.hostname
   };
 }

--- a/src/lib/attribution/storage/adapter.ts
+++ b/src/lib/attribution/storage/adapter.ts
@@ -26,11 +26,7 @@ export interface AttributionStorageStatusSnapshot {
   scope: AttributionStorageScope;
 }
 
-export type AttributionStorageMode = 'cookie' | 'localStorage';
-
-export type AttributionAdapterOptions = AttributionStorageOptions & {
-  storageMode?: AttributionStorageMode;
-};
+export type AttributionAdapterOptions = AttributionStorageOptions;
 
 const defaultStatus: AttributionStorageStatusSnapshot = {
   status: 'unavailable',
@@ -48,23 +44,6 @@ function setCurrentStatus(result: AttributionSnapshotResult): AttributionSnapsho
 export function loadAttributionSnapshot(
   options: AttributionAdapterOptions = {}
 ): AttributionSnapshotResult {
-  if (options.storageMode === 'localStorage') {
-    const legacy = readLegacyAttribution();
-    if (legacy.ok && legacy.value) {
-      return setCurrentStatus({
-        status: 'localStorage-fallback',
-        reason: 'legacy-pair-valid',
-        value: legacy.value,
-        scope: 'host'
-      });
-    }
-    return setCurrentStatus({
-      status: 'unavailable',
-      reason: legacy.reason,
-      value: null,
-      scope: 'host'
-    });
-  }
   return setCurrentStatus(resolveAttributionSnapshot(options));
 }
 
@@ -95,23 +74,6 @@ export function saveAttributionSnapshot(
   snapshot: StoredAttribution,
   options: AttributionAdapterOptions = {}
 ): AttributionSnapshotResult {
-  if (options.storageMode === 'localStorage') {
-    const legacy = writeLegacyAttribution(snapshot);
-    if (legacy.ok) {
-      return setCurrentStatus({
-        status: 'localStorage-fallback',
-        reason: legacy.reason,
-        value: { ...snapshot, v: 1 } as StoredAttributionV1,
-        scope: 'host'
-      });
-    }
-    return setCurrentStatus({
-      status: 'unavailable',
-      reason: legacy.reason,
-      value: null,
-      scope: 'host'
-    });
-  }
   const written = writeAttributionCookiePair(snapshot, options);
   if (written.status === 'cookie' && written.value) {
     void clearLegacyAttribution();

--- a/src/lib/consultation.ts
+++ b/src/lib/consultation.ts
@@ -1,0 +1,20 @@
+import { isSupportedLocale, normalizeLocale, type LocaleCode } from '@/lib/locales';
+
+export function getLocaleFromPathname(pathname: string, fallback: string): LocaleCode {
+  const candidate = pathname.split('/').filter(Boolean)[0];
+  return candidate && isSupportedLocale(candidate)
+    ? normalizeLocale(candidate)
+    : normalizeLocale(fallback);
+}
+
+export function isContactHref(href: string): boolean {
+  try {
+    const url = new URL(href, 'https://fastgpt.io');
+    const isRelative = !/^(?:https?:)?\/\//i.test(href);
+    if (!isRelative && url.origin !== 'https://fastgpt.io') return false;
+    const pathname = url.pathname.replace(/\/$/, '');
+    return pathname === '/contact' || /\/contact$/.test(pathname);
+  } catch {
+    return href === '/contact' || href.startsWith('/contact?');
+  }
+}


### PR DESCRIPTION
## Summary
- Add a standalone localized contact page and an in-site consultation modal for business CTA links.
- Submit visitor_id, attribution, and UTM fields to the CRM contact endpoint, with a clear configuration error when CRM is not configured.
- Make consultation links internal and keep attribution storage Cookie-first with localStorage fallback.

## Validation
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`

The CRM API must be configured with `NEXT_PUBLIC_CRM_API_URL` including `/api/v1`, and the site origin must be allowed by CRM CORS.