### PR TITLE
feat: improve contact form and contact page embedding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,5 @@ COPY --from=builder /app/out /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY nginx-security-headers.conf /etc/nginx/security-headers.conf
 COPY --from=builder /app/.next/nginx-redirects.conf /etc/nginx/generated-redirects.conf
+COPY nginx-embeddable-security-headers.conf /etc/nginx/embeddable-security-headers.conf
 RUN nginx -t

--- a/nginx-embeddable-security-headers.conf
+++ b/nginx-embeddable-security-headers.conf
@@ -1,0 +1,8 @@
+# Security headers for pages that are intentionally embeddable.
+# This policy is used only by the contact page locations in nginx.conf.
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.baidu.com hm.baidu.com track.fastgpt.cn *.feishu.cn cloudflareinsights.com *.cloudflareinsights.com rybbit.io *.rybbit.io www.clarity.ms *.clarity.ms; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' *.fastgpt.io *.fastgpt.cn *.sealos.io *.sealoshzh.site *.googletagmanager.com *.google-analytics.com cloudflareinsights.com *.cloudflareinsights.com rybbit.io *.rybbit.io www.clarity.ms *.clarity.ms api.github.com; frame-ancestors *; base-uri 'self'; form-action 'self'; media-src 'self' https:;" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -23,6 +23,16 @@ server {
       return 301 $locale_redirect_target$is_args$args;
   }
 
+  # The contact form is intentionally embeddable by external pages.
+  # Keep this before the generic trailing-slash redirect so the final page
+  # response uses the embeddable policy instead of X-Frame-Options: DENY.
+  location ~ ^/(?:contact|(?:en|zh|zh-hant|ja|ar|vi|th|id|ms)/contact)$ {
+      add_header Cache-Control "public, max-age=3600, stale-while-revalidate=86400";
+      add_header X-Cache-Status "HIT-CONTACT";
+      include /etc/nginx/embeddable-security-headers.conf;
+      try_files $uri $uri.html $uri/ =404;
+  }
+
   # Strip trailing slashes — Next.js uses trailingSlash: false,
   # so localized trailing-slash paths resolve to their extensionless pages.
   # Without this, nginx tries to serve the directory and returns 403.

--- a/public/_headers
+++ b/public/_headers
@@ -28,3 +28,15 @@
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   Cross-Origin-Opener-Policy: same-origin-allow-popups
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.baidu.com hm.baidu.com track.fastgpt.cn *.feishu.cn cloudflareinsights.com *.cloudflareinsights.com rybbit.io *.rybbit.io www.clarity.ms *.clarity.ms; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' *.fastgpt.io *.fastgpt.cn *.sealos.io *.sealoshzh.site *.googletagmanager.com *.google-analytics.com cloudflareinsights.com *.cloudflareinsights.com rybbit.io *.rybbit.io www.clarity.ms *.clarity.ms api.github.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; media-src 'self' https:;
+
+# The contact page is intentionally embeddable by external pages. The ! lines
+# detach the restrictive headers inherited from the catch-all rule.
+/contact
+  ! X-Frame-Options
+  ! Content-Security-Policy
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.baidu.com hm.baidu.com track.fastgpt.cn *.feishu.cn cloudflareinsights.com *.cloudflareinsights.com rybbit.io *.rybbit.io www.clarity.ms *.clarity.ms; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' *.fastgpt.io *.fastgpt.cn *.sealos.io *.sealoshzh.site *.googletagmanager.com *.google-analytics.com cloudflareinsights.com *.cloudflareinsights.com rybbit.io *.rybbit.io www.clarity.ms *.clarity.ms api.github.com; frame-ancestors *; base-uri 'self'; form-action 'self'; media-src 'self' https:;
+
+/*/contact
+  ! X-Frame-Options
+  ! Content-Security-Policy
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.baidu.com hm.baidu.com track.fastgpt.cn *.feishu.cn cloudflareinsights.com *.cloudflareinsights.com rybbit.io *.rybbit.io www.clarity.ms *.clarity.ms; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' *.fastgpt.io *.fastgpt.cn *.sealos.io *.sealoshzh.site *.googletagmanager.com *.google-analytics.com cloudflareinsights.com *.cloudflareinsights.com rybbit.io *.rybbit.io www.clarity.ms *.clarity.ms api.github.com; frame-ancestors *; base-uri 'self'; form-action 'self'; media-src 'self' https:;

--- a/scripts/verify-p0.js
+++ b/scripts/verify-p0.js
@@ -76,6 +76,10 @@ async function verifyImage() {
 
 function verifyNginxHeaders() {
   const headerConfig = fs.readFileSync(path.join(rootDir, 'nginx-security-headers.conf'), 'utf8');
+  const embeddableHeaderConfig = fs.readFileSync(
+    path.join(rootDir, 'nginx-embeddable-security-headers.conf'),
+    'utf8'
+  );
   const nginxConfig = fs.readFileSync(path.join(rootDir, 'nginx.conf'), 'utf8');
   const dockerfile = fs.readFileSync(path.join(rootDir, 'Dockerfile'), 'utf8');
   const requiredHeaders = [
@@ -93,6 +97,33 @@ function verifyNginxHeaders() {
   const includeCount = (nginxConfig.match(/include \/etc\/nginx\/security-headers\.conf;/g) || [])
     .length;
   assert.equal(includeCount, 11, 'Security headers must cover the server and all cache locations');
+  assert(headerConfig.includes('add_header X-Frame-Options "DENY"'), 'Default pages must deny framing');
+  assert(
+    !embeddableHeaderConfig.includes('X-Frame-Options'),
+    'Embeddable pages must not send X-Frame-Options'
+  );
+  assert(
+    embeddableHeaderConfig.includes('frame-ancestors *'),
+    'Embeddable pages must allow framing from external pages'
+  );
+  assert(
+    nginxConfig.includes('location ~ ^/(?:contact|(?:en|zh|zh-hant|ja|ar|vi|th|id|ms)/contact)$'),
+    'Contact routes must use a dedicated embeddable location'
+  );
+  assert(
+    nginxConfig.includes('include /etc/nginx/embeddable-security-headers.conf;'),
+    'Contact routes must use the embeddable security headers'
+  );
+
+  const cloudflareHeaders = fs.readFileSync(path.join(rootDir, 'public', '_headers'), 'utf8');
+  assert(
+    cloudflareHeaders.includes('/contact\n  ! X-Frame-Options'),
+    'Cloudflare contact rule must detach X-Frame-Options'
+  );
+  assert(
+    cloudflareHeaders.includes('/*/contact\n  ! X-Frame-Options'),
+    'Cloudflare localized contact rule must detach X-Frame-Options'
+  );
 
   assert(
     nginxConfig.includes('include /etc/nginx/generated-redirects.conf;'),

--- a/src/components/contact/ConsultationProvider.tsx
+++ b/src/components/contact/ConsultationProvider.tsx
@@ -137,9 +137,6 @@ export default function ConsultationProvider({
         createPortal(
           <div
             className="fixed inset-0 z-[100] flex items-end justify-center bg-[#101828]/55 p-0 backdrop-blur-[2px] sm:items-center sm:p-6"
-            onMouseDown={(event) => {
-              if (event.target === event.currentTarget) close();
-            }}
           >
             <div
               ref={dialogRef}

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -10,6 +10,11 @@ import {
 } from '@/lib/leadAttribution';
 import { fetchWithTimeout } from '@/lib/fetchWithTimeout';
 import {
+  clearContactFormDraft,
+  readContactFormDraft,
+  writeContactFormDraft
+} from '@/lib/contactFormStorage';
+import {
   CONTACT_OPTIONS,
   INITIAL_CONTACT_FORM,
   type ContactFormValues,
@@ -310,6 +315,22 @@ export default function ContactForm({ locale, variant = 'page', onDone }: Contac
   const [touchedFields, setTouchedFields] = useState<
     Partial<Record<keyof ContactFormValues, boolean>>
   >({});
+  const [hasLoadedDraft, setHasLoadedDraft] = useState(false);
+
+  useEffect(() => {
+    const draft = readContactFormDraft();
+    if (draft) setValues(draft);
+    setHasLoadedDraft(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hasLoadedDraft) return;
+    if (Object.values(values).some((value) => value.length > 0)) {
+      writeContactFormDraft(values);
+    } else {
+      clearContactFormDraft();
+    }
+  }, [hasLoadedDraft, values]);
 
   useEffect(() => {
     queueMicrotask(() => {
@@ -384,6 +405,7 @@ export default function ContactForm({ locale, variant = 'page', onDone }: Contac
   };
 
   const reset = () => {
+    clearContactFormDraft();
     setValues(INITIAL_CONTACT_FORM);
     setError('');
     setFieldErrors({});
@@ -450,6 +472,7 @@ export default function ContactForm({ locale, variant = 'page', onDone }: Contac
         );
       }
 
+      clearContactFormDraft();
       setStatus('success');
     } catch (submitError) {
       setError(submitError instanceof Error ? submitError.message : copy.genericError);

--- a/src/lib/contactFormStorage.ts
+++ b/src/lib/contactFormStorage.ts
@@ -1,0 +1,72 @@
+import type { ContactFormValues } from '@/components/contact/contactCopy';
+
+export const CONTACT_FORM_STORAGE_KEY = 'fastgpt_contact_form_draft';
+
+const CONTACT_FORM_FIELDS: readonly (keyof ContactFormValues)[] = [
+  'name',
+  'phone',
+  'company',
+  'position',
+  'usedOpenSource',
+  'consultationTopic',
+  'projectStage',
+  'budget',
+  'notes'
+];
+
+function getStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isContactFormValues(value: unknown): value is ContactFormValues {
+  if (!isRecord(value)) return false;
+
+  return CONTACT_FORM_FIELDS.every((field) => typeof value[field] === 'string');
+}
+
+export function readContactFormDraft(): ContactFormValues | null {
+  const storage = getStorage();
+  if (!storage) return null;
+
+  try {
+    const raw = storage.getItem(CONTACT_FORM_STORAGE_KEY);
+    if (!raw) return null;
+
+    const parsed: unknown = JSON.parse(raw);
+    return isContactFormValues(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeContactFormDraft(values: ContactFormValues): void {
+  const storage = getStorage();
+  if (!storage) return;
+
+  try {
+    storage.setItem(CONTACT_FORM_STORAGE_KEY, JSON.stringify(values));
+  } catch {
+    // Form input must continue to work when localStorage is unavailable.
+  }
+}
+
+export function clearContactFormDraft(): void {
+  const storage = getStorage();
+  if (!storage) return;
+
+  try {
+    storage.removeItem(CONTACT_FORM_STORAGE_KEY);
+  } catch {
+    // Ignore cleanup failures so a successful submission is still displayed.
+  }
+}


### PR DESCRIPTION
## What changed

- Persist contact form drafts in `localStorage`, restore them when the form opens, and clear them after a successful submission.
- Keep failed submissions recoverable and make storage failures non-blocking.
- Prevent the consultation modal from closing when the backdrop is clicked.
- Add embeddable security-header rules for contact pages and extend P0 checks for those routes.

## Why

Users can lose partially completed sales inquiry details when a page is refreshed or dismissed accidentally. The contact page also needs an explicit embedding policy for external integrations.

## Validation

- `npm run lint` passed.
- `npx tsc --noEmit --incremental false --pretty false` passed.
- `npm run build` passed.
- `npm run verify:p0` passed.
- `git diff --check` passed.
