### PR TITLE
feat: add explicit contact embed route

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -33,6 +33,13 @@ server {
       try_files $uri $uri.html $uri/ =404;
   }
 
+  location ~ ^/(?:contact/embed|(?:en|zh|zh-hant)/contact/embed)$ {
+      add_header Cache-Control "public, max-age=3600, stale-while-revalidate=86400";
+      add_header X-Cache-Status "HIT-CONTACT-EMBED";
+      include /etc/nginx/embeddable-security-headers.conf;
+      try_files $uri $uri.html $uri/ =404;
+  }
+
   # Strip trailing slashes — Next.js uses trailingSlash: false,
   # so localized trailing-slash paths resolve to their extensionless pages.
   # Without this, nginx tries to serve the directory and returns 403.

--- a/public/_headers
+++ b/public/_headers
@@ -40,3 +40,15 @@
   ! X-Frame-Options
   ! Content-Security-Policy
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.baidu.com hm.baidu.com track.fastgpt.cn *.feishu.cn cloudflareinsights.com *.cloudflareinsights.com rybbit.io *.rybbit.io www.clarity.ms *.clarity.ms; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' *.fastgpt.io *.fastgpt.cn *.sealos.io *.sealoshzh.site *.googletagmanager.com *.google-analytics.com cloudflareinsights.com *.cloudflareinsights.com rybbit.io *.rybbit.io www.clarity.ms *.clarity.ms api.github.com; frame-ancestors *; base-uri 'self'; form-action 'self'; media-src 'self' https:;
+
+# Explicit iframe form routes. These routes render the minimal form layout
+# server-side, so embedding does not depend on client-side frame detection.
+/contact/embed
+  ! X-Frame-Options
+  ! Content-Security-Policy
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.baidu.com hm.baidu.com track.fastgpt.cn *.feishu.cn cloudflareinsights.com *.cloudflareinsights.com rybbit.io *.rybbit.io www.clarity.ms *.clarity.ms; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' *.fastgpt.io *.fastgpt.cn *.sealos.io *.sealoshzh.site *.googletagmanager.com *.google-analytics.com cloudflareinsights.com *.cloudflareinsights.com rybbit.io *.rybbit.io www.clarity.ms *.clarity.ms api.github.com; frame-ancestors *; base-uri 'self'; form-action 'self'; media-src 'self' https:;
+
+/*/contact/embed
+  ! X-Frame-Options
+  ! Content-Security-Policy
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.baidu.com hm.baidu.com track.fastgpt.cn *.feishu.cn cloudflareinsights.com *.cloudflareinsights.com rybbit.io *.rybbit.io www.clarity.ms *.clarity.ms; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' *.fastgpt.io *.fastgpt.cn *.sealos.io *.sealoshzh.site *.googletagmanager.com *.google-analytics.com cloudflareinsights.com *.cloudflareinsights.com rybbit.io *.rybbit.io www.clarity.ms *.clarity.ms api.github.com; frame-ancestors *; base-uri 'self'; form-action 'self'; media-src 'self' https:;

--- a/scripts/verify-p0.js
+++ b/scripts/verify-p0.js
@@ -114,6 +114,10 @@ function verifyNginxHeaders() {
     nginxConfig.includes('include /etc/nginx/embeddable-security-headers.conf;'),
     'Contact routes must use the embeddable security headers'
   );
+  assert(
+    nginxConfig.includes('location ~ ^/(?:contact/embed|(?:en|zh|zh-hant)/contact/embed)$'),
+    'Contact embed routes must use a dedicated embeddable location'
+  );
 
   const cloudflareHeaders = fs.readFileSync(path.join(rootDir, 'public', '_headers'), 'utf8');
   assert(
@@ -123,6 +127,14 @@ function verifyNginxHeaders() {
   assert(
     cloudflareHeaders.includes('/*/contact\n  ! X-Frame-Options'),
     'Cloudflare localized contact rule must detach X-Frame-Options'
+  );
+  assert(
+    cloudflareHeaders.includes('/contact/embed\n  ! X-Frame-Options'),
+    'Cloudflare contact embed rule must detach X-Frame-Options'
+  );
+  assert(
+    cloudflareHeaders.includes('/*/contact/embed\n  ! X-Frame-Options'),
+    'Cloudflare localized contact embed rule must detach X-Frame-Options'
   );
 
   assert(

--- a/src/app/[lang]/contact/embed/page.tsx
+++ b/src/app/[lang]/contact/embed/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from 'next';
+import ContactPage from '@/components/contact/ContactPage';
+import { getContactCopy } from '@/components/contact/contactCopy';
+import { normalizeLocale } from '@/lib/i18n';
+import { isContactPublishedLocale } from '@/lib/publishedLocales';
+import { getBuildLocaleCodes } from '@/lib/siteRouting';
+
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ lang: string }>;
+}): Promise<Metadata> {
+  const { lang } = await params;
+  const locale = normalizeLocale(lang);
+  const copy = getContactCopy(locale);
+  return {
+    title: `${copy.title} | FastGPT`,
+    description: copy.subtitle,
+    robots: {
+      index: false,
+      follow: false
+    }
+  };
+}
+
+export default async function LocalizedContactEmbedPage({
+  params
+}: {
+  params: Promise<{ lang: string }>;
+}) {
+  const { lang } = await params;
+  return <ContactPage locale={lang} embedded />;
+}
+
+export function generateStaticParams() {
+  return getBuildLocaleCodes()
+    .filter(isContactPublishedLocale)
+    .map((lang) => ({ lang }));
+}
+
+export const dynamicParams = false;

--- a/src/app/contact/embed/page.tsx
+++ b/src/app/contact/embed/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+import ContactPage from '@/components/contact/ContactPage';
+import { getContactCopy } from '@/components/contact/contactCopy';
+import { defaultLocale } from '@/lib/i18n';
+
+export function generateMetadata(): Metadata {
+  const copy = getContactCopy(defaultLocale);
+  return {
+    title: `${copy.title} | FastGPT`,
+    description: copy.subtitle,
+    robots: {
+      index: false,
+      follow: false
+    }
+  };
+}
+
+export default function DefaultContactEmbedPage() {
+  return <ContactPage locale={defaultLocale} embedded />;
+}

--- a/src/components/contact/ContactPage.tsx
+++ b/src/components/contact/ContactPage.tsx
@@ -12,23 +12,22 @@ import { getDefaultLocalePath } from '@/lib/localizedRoutes';
 import { normalizeLocale } from '@/lib/locales';
 import { contactPublishedLocaleCodes } from '@/lib/publishedLocales';
 
-function isEmbeddedPage() {
-  try {
-    return window.self !== window.top;
-  } catch {
-    return true;
-  }
-}
-
-export default function ContactPage({ locale }: { locale: string }) {
+export default function ContactPage({
+  locale,
+  embedded = false
+}: {
+  locale: string;
+  embedded?: boolean;
+}) {
   const router = useRouter();
   const [canGoBack, setCanGoBack] = useState(false);
-  const [isEmbedded, setIsEmbedded] = useState(false);
   const normalizedLocale = normalizeLocale(locale);
   const copy = getContactCopy(normalizedLocale);
   const homeHref = getDefaultLocalePath(normalizedLocale);
 
   useEffect(() => {
+    if (embedded) return;
+
     const referrer = document.referrer;
     let hasSameOriginReferrer = false;
 
@@ -40,20 +39,17 @@ export default function ContactPage({ locale }: { locale: string }) {
       }
     }
 
-    const embedded = isEmbeddedPage();
-
     queueMicrotask(() => {
-      setIsEmbedded(embedded);
       setCanGoBack(window.history.length > 1 && hasSameOriginReferrer);
     });
-  }, []);
+  }, [embedded]);
 
   return (
     <div
       className="home min-h-screen bg-white text-[#101828]"
-      data-embedded={isEmbedded ? 'true' : undefined}
+      data-embedded={embedded ? 'true' : undefined}
     >
-      {!isEmbedded && (
+      {!embedded && (
         <header className="border-b border-[#eaecf0] bg-white">
           <div className="mx-auto flex h-16 max-w-[1180px] items-center justify-between px-5 sm:px-8">
             <Link href={homeHref} className="flex items-center gap-2" aria-label="FastGPT Home">
@@ -83,11 +79,11 @@ export default function ContactPage({ locale }: { locale: string }) {
 
       <main
         className={
-          isEmbedded ? 'bg-white px-0 py-0' : 'bg-[#f8fafc] px-5 py-10 sm:px-8 sm:py-14 lg:py-16'
+          embedded ? 'bg-white px-0 py-0' : 'bg-[#f8fafc] px-5 py-10 sm:px-8 sm:py-14 lg:py-16'
         }
       >
-        <div className={isEmbedded ? 'mx-auto max-w-none' : 'mx-auto max-w-[820px]'}>
-          {!isEmbedded && (
+        <div className={embedded ? 'mx-auto max-w-none' : 'mx-auto max-w-[820px]'}>
+          {!embedded && (
             <div className="mb-8 max-w-[680px] sm:mb-10">
               <span className="mb-3 block text-[11px] font-semibold uppercase text-[#155eef]">
                 {copy.eyebrow}
@@ -104,7 +100,7 @@ export default function ContactPage({ locale }: { locale: string }) {
           <section
             aria-label={copy.title}
             className={
-              isEmbedded
+              embedded
                 ? 'overflow-hidden bg-white'
                 : 'overflow-hidden rounded-lg border border-[#dfe3e8] bg-white shadow-[0_8px_30px_rgba(16,24,40,0.06)]'
             }


### PR DESCRIPTION
## What changed

- Add `/contact/embed` and localized `/zh/contact/embed` routes for iframe usage.
- Render the embedded form layout from the server through an explicit `embedded` prop.
- Remove client-side iframe detection and the resulting first-render layout shift.
- Mark embed pages as `noindex, nofollow`.
- Add Cloudflare and Nginx embeddable security-header rules for the new routes.
- Extend the P0 header regression checks.

## Why

The previous implementation rendered the standalone contact page first and only switched to the minimal iframe layout after client-side frame detection. The explicit embed route makes the initial HTML stable and gives integrations a clear URL contract.

## Validation

- `npm run lint`
- `npx tsc --noEmit --incremental false --pretty false`
- `npm run build`
- `npm run verify:p0`
- `npm run verify:i18n-seo`
- Static export checks confirm standalone and embed pages render the expected shells.
