### PR TITLE
fix: pass attribution source secret into Home builds

### DIFF
--- a/.github/workflows/fastgpt-home-image.yml
+++ b/.github/workflows/fastgpt-home-image.yml
@@ -74,7 +74,7 @@ jobs:
             NEXT_PUBLIC_CRM_API_URL=${{ secrets.NEXT_PUBLIC_CRM_API_URL }}
             NEXT_PUBLIC_ATTRIBUTION_COOKIE_DOMAIN=.fastgpt.cn
             NEXT_PUBLIC_ATTRIBUTION_STORAGE_MODE=${{ vars.NEXT_PUBLIC_ATTRIBUTION_STORAGE_MODE }}
-            NEXT_PUBLIC_ATTRIBUTION_SOURCE=${{ vars.NEXT_PUBLIC_ATTRIBUTION_SOURCE }}
+            NEXT_PUBLIC_ATTRIBUTION_SOURCE=${{ secrets.NEXT_PUBLIC_ATTRIBUTION_SOURCE }}
       - uses: actions-hub/kubectl@master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -46,7 +46,7 @@ jobs:
           NEXT_PUBLIC_IO_HOME_URL: https://fastgpt.io
           NEXT_PUBLIC_USER_URL: https://cloud.fastgpt.io
           NEXT_PUBLIC_CRM_API_URL: ${{ secrets.NEXT_PUBLIC_CRM_API_URL }}
-          NEXT_PUBLIC_ATTRIBUTION_SOURCE: ${{ vars.NEXT_PUBLIC_ATTRIBUTION_SOURCE }}
+          NEXT_PUBLIC_ATTRIBUTION_SOURCE: ${{ secrets.NEXT_PUBLIC_ATTRIBUTION_SOURCE }}
         run: |
           pnpm install
           pnpm run build


### PR DESCRIPTION
## What changed

- Read `NEXT_PUBLIC_ATTRIBUTION_SOURCE` from GitHub Actions Secrets in the production image workflow.
- Read the same secret in the Preview workflow.

## Why

The repository secret existed, but both workflows referenced `vars.NEXT_PUBLIC_ATTRIBUTION_SOURCE`. The Docker build therefore received an empty value and the browser bundle fell back to `未知`. The Dockerfile ARG/ENV wiring is unchanged because it already forwards the build argument correctly.

## Validation

- Parsed both workflow files with Ruby YAML parser.
- Ran `git diff --check`.
- Rebases cleanly onto `upstream/main`.

After merge, the production image workflow must run to publish a new bundle.