### PR TITLE
fix: calculate submit source from current query

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ npm run build
 不要填写密钥等敏感信息。
 
 商务表单的业务来源使用独立的 `source` query 参数，例如
-`/zh/contact?source=feishu`。官网会通过 Cookie 保留该来源，并在商机表单请求 JSON
-的 `source` 字段中发送给 CRM；没有该参数时来源为 `未知`。UTM 仍可用于匿名渠道分析，但不参与
-表单提交来源，也不再作为飞书客户来源；显式 `source` 只在提交商机时发送给 CRM。
+`/zh/contact?source=feishu`。每次提交时，官网实时读取当前 URL 的 `source`；没有该参数时使用
+构建时默认值，未配置则为 `未知`。提交来源不读取 Cookie 或其他本地归因状态。UTM 仍可用于匿名渠道分析，
+但不参与表单提交来源，也不再作为飞书客户来源；显式 `source` 只在提交商机时发送给 CRM。
 表单接口只接收表单字段、`visitor_id` 和 `source`，UTM/channel 等字段由匿名访客上报接口独立发送。
 
 ## Build

--- a/src/lib/attribution/primitives/envelope.ts
+++ b/src/lib/attribution/primitives/envelope.ts
@@ -79,7 +79,6 @@ function canonicalizeTouchPoint(value: Record<string, unknown>): TouchPoint {
   return {
     channel_l1: value.channel_l1 as ChannelL1,
     channel_l2: value.channel_l2 as string,
-    source: typeof value.source === 'string' ? value.source : '未知',
     is_paid: value.is_paid as boolean,
     label: value.label as string,
     utm_source: value.utm_source as string,

--- a/src/lib/leadAttribution.ts
+++ b/src/lib/leadAttribution.ts
@@ -48,7 +48,6 @@ export const DEFAULT_ATTRIBUTION_SOURCE = configuredAttributionSource?.slice(0, 
 export interface TouchPoint {
   channel_l1: ChannelL1;
   channel_l2: string; // 具体来源，如 Bing / 豆包 / 知乎；无则空串
-  source: string; // 显式业务来源；无则“未知”
   is_paid: boolean;
   label: string; // 人类可读：l2 ? `${l1中文? no -> l1} · ${l2}` : l1（这里用 l1 key 拼，中文在后端映射）
   utm_source: string;
@@ -177,7 +176,6 @@ export function classifyVisit(input: {
   now: string;
 }): TouchPoint {
   const params = new URLSearchParams(input.search || '');
-  const source = (params.get('source') || '').trim() || DEFAULT_ATTRIBUTION_SOURCE;
   const utm_source = params.get('utm_source') || '';
   const utm_medium = (params.get('utm_medium') || '').toLowerCase();
   const utm_campaign = params.get('utm_campaign') || '';
@@ -192,7 +190,6 @@ export function classifyVisit(input: {
     '';
 
   const base = {
-    source,
     utm_source,
     utm_medium,
     utm_campaign,
@@ -331,17 +328,9 @@ export function trackVisit(): void {
     // first_touch：只在第一次写入
     const first = stored?.first ?? current;
 
-    // last_touch：非 Direct 或显式 source 才更新；无 source 的 Direct 不覆盖已有
+    // last_touch：Last Non-Direct Click —— 非 Direct 才更新；Direct 不覆盖已有
     let last = stored?.last ?? current;
-    if (current.channel_l1 !== 'direct' || current.source !== DEFAULT_ATTRIBUTION_SOURCE) {
-      last = {
-        ...current,
-        source:
-          current.source === DEFAULT_ATTRIBUTION_SOURCE
-            ? stored?.last.source ?? DEFAULT_ATTRIBUTION_SOURCE
-            : current.source
-      };
-    }
+    if (current.channel_l1 !== 'direct') last = current;
 
     const next: StoredAttribution = { visitor_id, first, last };
     saveAttributionSnapshot(next, getStorageOptions());
@@ -403,10 +392,8 @@ export function getAttributionPayload(): AttributionPayload {
 /** Return the explicit source for the current business submission only. */
 export function getSubmissionSource(): string {
   if (typeof window === 'undefined') return DEFAULT_ATTRIBUTION_SOURCE;
-  const stored = loadStoredAttribution();
-  if (!stored) return DEFAULT_ATTRIBUTION_SOURCE;
-  const { first, last } = stored;
-  return last.source !== DEFAULT_ATTRIBUTION_SOURCE ? last.source : first.source;
+  const source = new URLSearchParams(window.location.search).get('source')?.trim();
+  return source?.slice(0, 128) || DEFAULT_ATTRIBUTION_SOURCE;
 }
 
 /** Submit anonymous attribution to CRM after the local browser snapshot changes. */


### PR DESCRIPTION
## What changed

- Calculate the contact submission `source` from the current URL query on every submit.
- Fall back to `NEXT_PUBLIC_ATTRIBUTION_SOURCE`, then `未知` when the query is absent.
- Stop writing submission `source` into attribution Cookie/localStorage state.
- Keep UTM, referrer, channel, and other attribution fields independent for anonymous visitor reporting.
- Update the Home documentation to describe the no-cache submission behavior.

## Why

The previous implementation read the first or last cached attribution source. A visitor who had previously opened a URL such as `?source=docs` could therefore submit a later Home form without a source query and still send `docs` to CRM. Submission source must represent the current URL or the configured build fallback only.

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`
- Rebased onto `upstream/main`
