### PR TITLE
fix: align locale FAQ fallback and html lang metadata

### DIFF
--- a/scripts/verify-contact-page.js
+++ b/scripts/verify-contact-page.js
@@ -1,6 +1,7 @@
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
+const { pathToFileURL } = require('node:url');
 const {
   getDefaultLocale,
   getPublishedLocaleCodes,
@@ -43,20 +44,30 @@ function getExpectedContactRoute(locale) {
   return contactLocale === defaultLocale ? '/contact' : `/${contactLocale}/contact`;
 }
 
-function verifyContactQueryFlow() {
+async function verifyContactQueryFlow() {
+  const { appendForwardedAttributionQuery, getForwardedAttributionQuery } = await import(
+    pathToFileURL(path.join(root, 'src/lib/attribution/query.mjs')).href
+  );
   const contactSource = fs.readFileSync(path.join(root, 'src/lib/contact.ts'), 'utf8');
-  const formSource = fs.readFileSync(path.join(root, 'src/components/contact/ContactForm.tsx'), 'utf8');
+  const formSource = fs.readFileSync(
+    path.join(root, 'src/components/contact/ContactForm.tsx'),
+    'utf8'
+  );
   const attributionSource = fs.readFileSync(path.join(root, 'src/lib/leadAttribution.ts'), 'utf8');
+  const contactLinkScriptSource = fs.readFileSync(
+    path.join(root, 'src/lib/contactLinkAttribution.ts'),
+    'utf8'
+  );
 
   assert.match(
     contactSource,
-    /getContactUrl\(locale: string, search = ''\)/,
-    'Contact URL helper must accept the current query string'
+    /appendForwardedAttributionQuery\(path, search\)/,
+    'Contact URL helper must use the shared query-forwarding helper'
   );
   assert.match(
-    contactSource,
-    /ATTRIBUTION_QUERY_KEYS\.forEach/,
-    'Contact URL helper must use the attribution query allowlist'
+    contactLinkScriptSource,
+    /document\.addEventListener\('pointerdown'/,
+    'Contact links must preserve attribution before React hydration'
   );
   assert.match(
     formSource,
@@ -71,25 +82,27 @@ function verifyContactQueryFlow() {
 
   const landingQuery =
     'source=partner&utm_source=google&utm_campaign=launch&click_id=abc123&email=drop-me';
-  const forwarded = new URLSearchParams();
-  const incoming = new URLSearchParams(landingQuery);
-  const allowedKeys = ['source', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'click_id'];
-  for (const key of allowedKeys) {
-    const value = incoming.get(key);
-    if (value) forwarded.set(key, value);
-  }
-
   assert.equal(
-    forwarded.toString(),
+    getForwardedAttributionQuery(landingQuery),
     'source=partner&utm_source=google&utm_campaign=launch&click_id=abc123',
     'Contact query forwarding must preserve approved attribution values only'
   );
   assert.equal(
-    new URLSearchParams(forwarded).get('source'),
-    'partner',
-    'Landing source must survive Contact navigation into the submission payload'
+    appendForwardedAttributionQuery('/zh-hant/contact#consultation', landingQuery),
+    '/zh-hant/contact?source=partner&utm_source=google&utm_campaign=launch&click_id=abc123#consultation',
+    'Contact query forwarding must preserve the localized path and hash'
   );
-  assert.equal(new URLSearchParams(forwarded).has('email'), false);
+  assert.equal(
+    new URLSearchParams(getForwardedAttributionQuery(landingQuery)).has('email'),
+    false,
+    'Contact query forwarding must remove unrelated values'
+  );
+  assert.equal(
+    new URLSearchParams(getForwardedAttributionQuery(`source=${'x'.repeat(200)}`)).get('source')
+      ?.length,
+    128,
+    'Contact query forwarding must enforce the source field cap'
+  );
 }
 
 function verifyBuiltResourcePolicy() {
@@ -174,38 +187,68 @@ function verifyCrmState() {
   );
 }
 
-const pages = [
-  ['contact.html', titles[defaultLocale] || titles.en],
-  ...contactLocales
-    .filter((locale) => locale !== defaultLocale)
-    .map((locale) => [
-      `${locale}/contact.html`,
-      titles[locale] || titles.en
-    ])
-];
+function getContactPath(href) {
+  if (!href || href.startsWith('#') || /^(?:https?:|\/\/|mailto:|tel:|javascript:)/i.test(href)) {
+    return null;
+  }
 
-for (const [file, title] of pages) {
-  const content = fs.readFileSync(path.join(output, file), 'utf8');
-  assert.match(content, new RegExp(title), `${file} is missing its localized title`);
-  assert.ok(content.includes('rgba(59,130,246,0.12)'), `${file} is missing the unified contact hero treatment`);
-  assert.ok(!content.includes('rgba(251,208,223'), `${file} still contains the legacy purple contact treatment`);
+  const [withoutHash] = href.split('#', 1);
+  const [pathname] = withoutHash.split('?', 1);
+  return /(?:^|\/)contact(?:\/embed)?\/?$/.test(pathname) ? pathname : null;
 }
 
-const homepageRoutes = publishedLocales.map((locale) => ({
-  locale,
-  route: locale === defaultLocale ? '/' : `/${locale}`
-}));
+function verifyAllBuiltContactLinks() {
+  const htmlFiles = [];
 
-for (const { locale, route } of homepageRoutes) {
-  const content = resolveHtml(route);
-  const expectedHref = getExpectedContactRoute(locale);
-  const contactHrefs = getContactHrefs(content);
-  assert(contactHrefs.length > 0, `${route} is missing a Contact CTA`);
-  assert(
-    contactHrefs.every((href) => href === expectedHref),
-    `${route} contains an unreachable Contact href: ${contactHrefs.join(', ')}`
+  function collectHtmlFiles(directory) {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const target = path.join(directory, entry.name);
+      if (entry.isDirectory()) collectHtmlFiles(target);
+      else if (entry.name.endsWith('.html')) htmlFiles.push(target);
+    }
+  }
+
+  collectHtmlFiles(output);
+  for (const file of htmlFiles) {
+    const content = fs.readFileSync(file, 'utf8');
+    for (const match of content.matchAll(/href="([^"]+)"/g)) {
+      const contactPath = getContactPath(match[1]);
+      if (!contactPath) continue;
+      assert(
+        resolveHtmlPath(contactPath),
+        `${path.relative(root, file)} points to missing Contact HTML at ${contactPath}`
+      );
+    }
+  }
+}
+
+function verifyContactEmbedRoutes() {
+  const embedSourcePaths = [
+    path.join(root, 'src/app/contact/embed/page.tsx'),
+    path.join(root, 'src/app/[lang]/contact/embed/page.tsx')
+  ];
+  for (const sourcePath of embedSourcePaths) {
+    const source = fs.readFileSync(sourcePath, 'utf8');
+    assert.match(
+      source,
+      /<ContactForm locale=\{locale\} variant="modal" \/>/,
+      `${path.relative(root, sourcePath)} must render the Contact form`
+    );
+  }
+
+  const routes = [
+    '/contact/embed',
+    ...contactLocales.map((locale) => `/${locale}/contact/embed`)
+  ].filter(
+    (route, index, allRoutes) => allRoutes.indexOf(route) === index && resolveHtmlPath(route)
   );
-  assert(resolveHtmlPath(expectedHref), `${route} points to missing static HTML at ${expectedHref}`);
+
+  for (const route of routes) {
+    const html = resolveHtml(route);
+    assert(html.includes('data-contact-embed="true"'), `${route} is missing its embed marker`);
+    // ContactForm is a client component, so its form element is not present in static HTML.
+    assert(!html.includes('data-published-locales'), `${route} must not render the site Navbar`);
+  }
 }
 
 function sourceFiles(directory) {
@@ -216,17 +259,73 @@ function sourceFiles(directory) {
   });
 }
 
-for (const file of sourceFiles(path.join(root, 'src'))) {
-  const content = fs.readFileSync(file, 'utf8');
-  for (const resource of ['fael3z0zfze.feishu.cn/share/base/form', 'picsum.photos', 'api.fontshare.com']) {
-    assert(!content.includes(resource), `${path.relative(root, file)} still references ${resource}`);
+async function main() {
+  const pages = [
+    ['contact.html', titles[defaultLocale] || titles.en],
+    ...contactLocales
+      .filter((locale) => locale !== defaultLocale)
+      .map((locale) => [`${locale}/contact.html`, titles[locale] || titles.en])
+  ];
+
+  for (const [file, title] of pages) {
+    const content = fs.readFileSync(path.join(output, file), 'utf8');
+    assert.match(content, new RegExp(title), `${file} is missing its localized title`);
+    assert.ok(
+      content.includes('rgba(59,130,246,0.12)'),
+      `${file} is missing the unified contact hero treatment`
+    );
+    assert.ok(
+      !content.includes('rgba(251,208,223'),
+      `${file} still contains the legacy purple contact treatment`
+    );
   }
+
+  const homepageRoutes = publishedLocales.map((locale) => ({
+    locale,
+    route: locale === defaultLocale ? '/' : `/${locale}`
+  }));
+
+  for (const { locale, route } of homepageRoutes) {
+    const content = resolveHtml(route);
+    const expectedHref = getExpectedContactRoute(locale);
+    const contactHrefs = getContactHrefs(content);
+    assert(contactHrefs.length > 0, `${route} is missing a Contact CTA`);
+    assert(
+      contactHrefs.every((href) => href === expectedHref),
+      `${route} contains an unreachable Contact href: ${contactHrefs.join(', ')}`
+    );
+    assert(
+      resolveHtmlPath(expectedHref),
+      `${route} points to missing static HTML at ${expectedHref}`
+    );
+  }
+
+  for (const file of sourceFiles(path.join(root, 'src'))) {
+    const content = fs.readFileSync(file, 'utf8');
+    for (const resource of [
+      'fael3z0zfze.feishu.cn/share/base/form',
+      'picsum.photos',
+      'api.fontshare.com'
+    ]) {
+      assert(
+        !content.includes(resource),
+        `${path.relative(root, file)} still references ${resource}`
+      );
+    }
+  }
+
+  await verifyContactQueryFlow();
+  verifyBuiltResourcePolicy();
+  verifyCrmState();
+  verifyAllBuiltContactLinks();
+  verifyContactEmbedRoutes();
+
+  console.log(
+    `Contact page verification passed: ${pages.length} routes, ${homepageRoutes.length} localized entry paths, all Contact links, embeds, CRM state and attribution flow verified.`
+  );
 }
 
-verifyContactQueryFlow();
-verifyBuiltResourcePolicy();
-verifyCrmState();
-
-console.log(
-  `Contact page verification passed: ${pages.length} routes, ${homepageRoutes.length} localized entry paths, CRM state and attribution flow verified.`
-);
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/verify-contact-page.js
+++ b/scripts/verify-contact-page.js
@@ -236,12 +236,9 @@ function verifyContactEmbedRoutes() {
     );
   }
 
-  const routes = [
-    '/contact/embed',
-    ...contactLocales.map((locale) => `/${locale}/contact/embed`)
-  ].filter(
-    (route, index, allRoutes) => allRoutes.indexOf(route) === index && resolveHtmlPath(route)
-  );
+  const buildLocales = contactLocales.filter((locale) => locale !== defaultLocale);
+  if (buildLocales.length === 0) buildLocales.push(defaultLocale);
+  const routes = ['/contact/embed', ...buildLocales.map((locale) => `/${locale}/contact/embed`)];
 
   for (const route of routes) {
     const html = resolveHtml(route);

--- a/scripts/verify-i18n-seo.js
+++ b/scripts/verify-i18n-seo.js
@@ -11,6 +11,7 @@ const {
   getProductionBaseUrls,
   resolveSiteVariant
 } = require('./lib/site-variant');
+const { locales } = require('../src/config/site-routing.json');
 
 const rootDir = path.join(__dirname, '..');
 const outDir = path.join(rootDir, 'out');
@@ -29,6 +30,9 @@ const compareSlugs = [
 const pageLanguages = ['en', 'zh-CN', 'zh-Hant', 'ja', 'ar', 'vi', 'th', 'id', 'ms'];
 const faqLanguages = ['en', 'zh-CN'];
 const contactLanguages = ['en', 'zh-CN', 'zh-Hant'];
+const htmlLangs = Object.fromEntries(
+  Object.values(locales).map((locale) => [locale.hreflang, locale.htmlLang])
+);
 const localePaths = {
   en: '',
   'zh-CN': '',
@@ -81,6 +85,10 @@ function getMetaDescription(html) {
   return getAttribute(meta || '', 'content') || '';
 }
 
+function getHtmlLang(html) {
+  return getAttribute(getTags(html, 'html')[0] || '', 'lang') || '';
+}
+
 function getRobots(html) {
   const meta = getTags(html, 'meta').find((tag) => getAttribute(tag, 'name') === 'robots');
   return getAttribute(meta || '', 'content') || '';
@@ -115,6 +123,11 @@ function normalizeUrl(url) {
 
 function verifyPage(route, locale, pathSuffix, languages) {
   const html = resolveHtml(route);
+  assert.equal(
+    getHtmlLang(html),
+    htmlLangs[locale] || locale,
+    `${route} has an unexpected html lang`
+  );
   assert.equal(
     normalizeUrl(getCanonical(html, route)),
     normalizeUrl(expectedLocaleUrl(locale, pathSuffix)),

--- a/src/app/[lang]/contact/embed/page.tsx
+++ b/src/app/[lang]/contact/embed/page.tsx
@@ -34,7 +34,7 @@ export default async function LocalizedContactEmbedPage({
   const copy = getContactCopy(locale);
 
   return (
-    <main className="home min-h-screen bg-white font-sans text-ink">
+    <main data-contact-embed="true" className="home min-h-screen bg-white font-sans text-ink">
       <div className="mx-auto max-w-2xl px-5 py-8 sm:px-8">
         <header className="mb-6">
           <p className="m-0 text-[12px] font-medium uppercase tracking-[0.16em] text-ink-muted">

--- a/src/app/contact/embed/page.tsx
+++ b/src/app/contact/embed/page.tsx
@@ -21,7 +21,7 @@ export default async function DefaultContactEmbedPage() {
   const copy = getContactCopy(locale);
 
   return (
-    <main className="home min-h-screen bg-white font-sans text-ink">
+    <main data-contact-embed="true" className="home min-h-screen bg-white font-sans text-ink">
       <div className="mx-auto max-w-2xl px-5 py-8 sm:px-8">
         <header className="mb-6">
           <p className="m-0 text-[12px] font-medium uppercase tracking-[0.16em] text-ink-muted">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { siteConfig } from '@/config/site';
 import { cn } from '@/lib/utils';
 import { defaultLocale } from '@/lib/i18n';
 import { htmlLangScript } from '@/lib/htmlLang';
+import { contactLinkAttributionScript } from '@/lib/contactLinkAttribution';
 import { localeDirections } from '@/lib/locales';
 import '@/styles/globals.css';
 import { Viewport } from 'next';
@@ -64,6 +65,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         {/* Synchronously set html[lang] from URL path — must run before hydration */}
         <script dangerouslySetInnerHTML={{ __html: htmlLangScript }} />
+        {/* Preserve approved attribution query keys before interactive hydration. */}
+        <script dangerouslySetInnerHTML={{ __html: contactLinkAttributionScript }} />
       </head>
       <body
         className={cn(

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils';
 import { defaultLocale } from '@/lib/i18n';
 import { htmlLangScript } from '@/lib/htmlLang';
 import { contactLinkAttributionScript } from '@/lib/contactLinkAttribution';
-import { localeDirections } from '@/lib/locales';
+import { localeDirections, localeHtmlLangs } from '@/lib/locales';
 import '@/styles/globals.css';
 import { Viewport } from 'next';
 import { Inter as FontSans } from 'next/font/google';
@@ -56,7 +56,7 @@ export const viewport: Viewport = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html
-      lang={defaultLocale}
+      lang={localeHtmlLangs[defaultLocale] || defaultLocale}
       dir={localeDirections[defaultLocale] || 'ltr'}
       className="dark"
       style={{ colorScheme: 'dark' }}

--- a/src/components/home/Footer.tsx
+++ b/src/components/home/Footer.tsx
@@ -32,6 +32,7 @@ type FooterT = {
 
 function buildColumns(t: FooterT['columns'], locale?: string): Column[] {
   const normalizedLocale = normalizeLocale(locale);
+  const faqLocale = normalizedLocale === 'zh' ? 'zh' : 'en';
 
   return [
     {
@@ -75,6 +76,11 @@ function buildColumns(t: FooterT['columns'], locale?: string): Column[] {
           href: 'https://solutions.fastgpt.cn/',
           external: true
         },
+        {
+          label: t.links.items.faq,
+          href: getDefaultLocalePath(faqLocale, '/faq'),
+          external: false
+        },
         ...(normalizedLocale === 'zh'
           ? [
               {
@@ -83,12 +89,7 @@ function buildColumns(t: FooterT['columns'], locale?: string): Column[] {
                 external: false
               }
             ]
-          : []),
-        {
-          label: t.links.items.faq,
-          href: getDefaultLocalePath(normalizedLocale, '/faq'),
-          external: false
-        }
+          : [])
       ]
     },
     {

--- a/src/components/home/hooks/useContactUrl.ts
+++ b/src/components/home/hooks/useContactUrl.ts
@@ -1,17 +1,30 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 import { useParams } from 'next/navigation';
 import { defaultLocale } from '@/lib/i18n';
 import { getContactUrl } from '@/lib/contact';
 
+function subscribeToLocationSearch(onChange: () => void) {
+  window.addEventListener('popstate', onChange);
+  return () => window.removeEventListener('popstate', onChange);
+}
+
+function getLocationSearch() {
+  return window.location.search;
+}
+
+function getServerLocationSearch() {
+  return '';
+}
+
 export function useContactUrl(locale?: string): string {
   const params = useParams<{ lang?: string }>();
-  const [search, setSearch] = useState('');
-
-  useEffect(() => {
-    setSearch(window.location.search);
-  }, []);
+  const search = useSyncExternalStore(
+    subscribeToLocationSearch,
+    getLocationSearch,
+    getServerLocationSearch
+  );
 
   return getContactUrl(locale || params?.lang || defaultLocale, search);
 }

--- a/src/lib/attribution/primitives/envelope.ts
+++ b/src/lib/attribution/primitives/envelope.ts
@@ -1,5 +1,7 @@
 import type { ChannelL1, StoredAttribution, TouchPoint } from '../../leadAttribution';
 
+export { ATTRIBUTION_QUERY_KEYS } from '../query.mjs';
+
 export const FIELD_CAPS = {
   visitor_id: 64,
   channel_l2: 128,
@@ -15,16 +17,6 @@ export const FIELD_CAPS = {
   landing_url: 2048,
   at: 40
 } as const;
-
-export const ATTRIBUTION_QUERY_KEYS = [
-  'source',
-  'utm_source',
-  'utm_medium',
-  'utm_campaign',
-  'utm_term',
-  'utm_content',
-  'click_id'
-] as const satisfies readonly (keyof typeof FIELD_CAPS)[];
 
 export type StoredAttributionV1 = StoredAttribution & { v: 1 };
 export type ValidationFailureReason =

--- a/src/lib/attribution/query.mjs
+++ b/src/lib/attribution/query.mjs
@@ -1,0 +1,40 @@
+export const ATTRIBUTION_QUERY_KEYS = Object.freeze([
+  'source',
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+  'click_id'
+]);
+
+export const ATTRIBUTION_QUERY_VALUE_CAPS = Object.freeze({
+  source: 128,
+  utm_source: 128,
+  utm_medium: 128,
+  utm_campaign: 256,
+  utm_term: 256,
+  utm_content: 256,
+  click_id: 256
+});
+
+export function getForwardedAttributionQuery(search = '') {
+  const incoming = new URLSearchParams(search);
+  const forwarded = new URLSearchParams();
+
+  for (const key of ATTRIBUTION_QUERY_KEYS) {
+    const value = incoming.get(key)?.trim().slice(0, ATTRIBUTION_QUERY_VALUE_CAPS[key]);
+    if (value) forwarded.set(key, value);
+  }
+
+  return forwarded.toString();
+}
+
+export function appendForwardedAttributionQuery(path, search = '') {
+  const hashIndex = path.indexOf('#');
+  const hash = hashIndex === -1 ? '' : path.slice(hashIndex);
+  const pathname = (hashIndex === -1 ? path : path.slice(0, hashIndex)).split('?')[0];
+  const query = getForwardedAttributionQuery(search);
+
+  return `${pathname}${query ? `?${query}` : ''}${hash}`;
+}

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -1,6 +1,6 @@
 import { normalizeLocale } from '@/lib/locales';
 import { getDefaultLocalePath } from '@/lib/clientNavigation';
-import { ATTRIBUTION_QUERY_KEYS } from '@/lib/attribution/primitives/envelope';
+import { appendForwardedAttributionQuery } from '@/lib/attribution/query.mjs';
 
 export const contactLocaleCodes = ['zh', 'en', 'zh-hant'] as const;
 
@@ -11,14 +11,5 @@ export function getContactLocale(locale: string) {
 
 export function getContactUrl(locale: string, search = ''): string {
   const path = getDefaultLocalePath(getContactLocale(locale), '/contact');
-  const incoming = new URLSearchParams(search);
-  const forwarded = new URLSearchParams();
-
-  ATTRIBUTION_QUERY_KEYS.forEach((key) => {
-    const value = incoming.get(key);
-    if (value) forwarded.set(key, value);
-  });
-
-  const query = forwarded.toString();
-  return query ? `${path}?${query}` : path;
+  return appendForwardedAttributionQuery(path, search);
 }

--- a/src/lib/contactLinkAttribution.ts
+++ b/src/lib/contactLinkAttribution.ts
@@ -1,0 +1,60 @@
+import 'server-only';
+import { ATTRIBUTION_QUERY_KEYS, ATTRIBUTION_QUERY_VALUE_CAPS } from '@/lib/attribution/query.mjs';
+
+const attributionKeysJson = JSON.stringify(ATTRIBUTION_QUERY_KEYS);
+const attributionValueCapsJson = JSON.stringify(ATTRIBUTION_QUERY_VALUE_CAPS);
+
+/**
+ * Keep Contact links attribution-safe before React hydration. Static export cannot
+ * render the current query string into an anchor, so this capture-phase handler
+ * updates the destination at the moment a user interacts with the link.
+ */
+export const contactLinkAttributionScript = `
+(function() {
+  var keys = ${attributionKeysJson};
+  var valueCaps = ${attributionValueCapsJson};
+
+  function updateContactHref(event) {
+    if (event.defaultPrevented || !(event.target instanceof Element)) return;
+
+    var anchor = event.target.closest('a[href]');
+    if (!anchor) return;
+
+    var rawHref = anchor.getAttribute('href') || '';
+    if (!rawHref || rawHref.charAt(0) === '#' || /^(?:mailto:|tel:|javascript:)/i.test(rawHref)) {
+      return;
+    }
+
+    var target;
+    try {
+      target = new URL(rawHref, window.location.href);
+    } catch (_error) {
+      return;
+    }
+
+    if (
+      target.origin !== window.location.origin ||
+      !/(?:^|\\/)contact(?:\\/embed)?\\/?$/.test(target.pathname)
+    ) {
+      return;
+    }
+
+    var incoming = new URLSearchParams(window.location.search);
+    var forwarded = new URLSearchParams();
+    keys.forEach(function(key) {
+      var value = incoming.get(key);
+      var maxLength = valueCaps[key];
+      if (value && maxLength) {
+        value = value.trim().slice(0, maxLength);
+        if (value) forwarded.set(key, value);
+      }
+    });
+
+    target.search = forwarded.toString() ? '?' + forwarded.toString() : '';
+    anchor.setAttribute('href', target.pathname + target.search + target.hash);
+  }
+
+  document.addEventListener('pointerdown', updateContactHref, true);
+  document.addEventListener('click', updateContactHref, true);
+})();
+`.trim();

--- a/src/lib/htmlLang.ts
+++ b/src/lib/htmlLang.ts
@@ -7,29 +7,31 @@
  * Supported locale paths are respected as-is.
  */
 
-import { localeDirections, normalizeLocale, supportedLocaleCodes } from '@/lib/locales';
+import { localeDirections, localeHtmlLangs, supportedLocaleCodes } from '@/lib/locales';
 import { getDefaultLocaleForSiteVariant } from '@/lib/siteRouting';
 
 const normalizedBuildDefaultLocale = getDefaultLocaleForSiteVariant();
 const localesJson = JSON.stringify(supportedLocaleCodes);
 const directionsJson = JSON.stringify(localeDirections);
+const htmlLangsJson = JSON.stringify(localeHtmlLangs);
 
 export const htmlLangScript = `
 (function() {
   var path = window.location.pathname;
   var locales = ${localesJson};
   var directions = ${directionsJson};
+  var htmlLangs = ${htmlLangsJson};
   var defaultLocale = '${normalizedBuildDefaultLocale}';
-  var lang = defaultLocale;
+  var localeCode = defaultLocale;
   for (var p = 0; p < locales.length; p++) {
     var code = locales[p];
     if (path === '/' + code || path.indexOf('/' + code + '/') === 0) {
-      lang = code;
+      localeCode = code;
       break;
     }
   }
-  document.documentElement.lang = lang;
-  document.documentElement.dir = directions[lang] || 'ltr';
+  document.documentElement.lang = htmlLangs[localeCode] || localeCode;
+  document.documentElement.dir = directions[localeCode] || 'ltr';
 
 })();
 `.trim();

--- a/src/lib/locales.ts
+++ b/src/lib/locales.ts
@@ -26,6 +26,11 @@ export const localeDirections = localeConfigs.reduce((acc, locale) => {
   return acc;
 }, {} as Record<LocaleCode, LocaleDirection>);
 
+export const localeHtmlLangs = localeConfigs.reduce((acc, locale) => {
+  acc[locale.code] = locale.htmlLang;
+  return acc;
+}, {} as Record<LocaleCode, string>);
+
 export function normalizeLocale(locale: string | undefined | null): LocaleCode {
   if (!locale) return 'en';
 


### PR DESCRIPTION
## What changed

- Keep production FAQ bilingual by site ownership: `zh` serves Simplified Chinese and all international locales reuse the English FAQ route.
- Keep the Technical Center link at the bottom of the Simplified Chinese Footer Links column.
- Derive runtime and initial document `lang` values from the routing manifest (`zh-CN`, `en-US`, `zh-Hant`, and the other configured BCP47 values).
- Extend i18n SEO verification to assert the generated HTML `lang` attribute.

## Why

International locale homepages previously generated FAQ links such as `/ja/faq`, although those locale-specific FAQ pages are not published. The runtime language script also replaced manifest BCP47 values with short locale codes.

## Validation

- `npx tsc --noEmit --incremental false`
- `npm run lint`
- CN and IO production builds
- `npm run verify:i18n-seo` (CN and IO)
- `npm run verify:contact`
- `npm run verify:p0`
- `npm run verify:p2`

`verify:p1` still reports the existing initial JavaScript budget at 260.5 KiB against a 260 KiB limit.