### PR TITLE
fix: improve contact hero and homepage scroll animations

### DIFF
--- a/scripts/verify-contact-page.js
+++ b/scripts/verify-contact-page.js
@@ -20,6 +20,9 @@ const variant = resolveSiteVariant();
 const defaultLocale = getDefaultLocale(variant);
 const publishedLocales = getPublishedLocaleCodes(variant);
 const contactLocales = publishedLocales.filter((locale) => titles[locale]);
+const fallbackContactLocales = publishedLocales.filter(
+  (locale) => !contactLocales.includes(locale)
+);
 
 function resolveHtmlPath(route) {
   const relativeRoute = route.replace(/^\/+|\/+$/g, '');
@@ -237,6 +240,7 @@ function verifyContactEmbedRoutes() {
   }
 
   const buildLocales = contactLocales.filter((locale) => locale !== defaultLocale);
+  buildLocales.push(...fallbackContactLocales.filter((locale) => locale !== defaultLocale));
   if (buildLocales.length === 0) buildLocales.push(defaultLocale);
   const routes = ['/contact/embed', ...buildLocales.map((locale) => `/${locale}/contact/embed`)];
 
@@ -261,7 +265,8 @@ async function main() {
     ['contact.html', titles[defaultLocale] || titles.en],
     ...contactLocales
       .filter((locale) => locale !== defaultLocale)
-      .map((locale) => [`${locale}/contact.html`, titles[locale] || titles.en])
+      .map((locale) => [`${locale}/contact.html`, titles[locale] || titles.en]),
+    ...fallbackContactLocales.map((locale) => [`${locale}/contact.html`, titles.en])
   ];
 
   for (const [file, title] of pages) {

--- a/scripts/verify-i18n-seo.js
+++ b/scripts/verify-i18n-seo.js
@@ -279,7 +279,11 @@ function verifyPublishedRoutes() {
   assert.equal(Boolean(resolveHtmlPath('/zh')), variant === 'cn' || variant === 'preview');
   assert.equal(Boolean(resolveHtmlPath('/ja')), variant === 'io' || variant === 'preview');
   assert(!resolveHtmlPath('/ja/faq'), 'Japanese FAQ must resolve as a real 404');
-  assert(!resolveHtmlPath('/ja/contact'), 'Japanese Contact must resolve as a real 404');
+  assert.equal(
+    Boolean(resolveHtmlPath('/ja/contact')),
+    variant === 'io' || variant === 'preview',
+    'Japanese Contact must be generated for international variants and absent from the CN build'
+  );
   assert(!resolveHtmlPath('/ja/tech-center'), 'Japanese technical center must resolve as a real 404');
   assert.equal(Boolean(resolveHtmlPath('/zh/contact')), variant === 'cn' || variant === 'preview');
   assert.equal(
@@ -359,6 +363,11 @@ function verifyContactExperience() {
   if (variant === 'cn') return;
 
   const traditionalContactHtml = resolveHtml('/zh-hant/contact');
+  const japaneseContactHtml = resolveHtml('/ja/contact');
+  assert(
+    japaneseContactHtml.includes('Contact FastGPT Sales'),
+    'Japanese Contact must fall back to the English Contact copy'
+  );
   if (process.env.NEXT_PUBLIC_CRM_API_URL) {
     for (const expectedCopy of [
       'placeholder="請輸入姓名"',

--- a/src/app/[lang]/contact/embed/page.tsx
+++ b/src/app/[lang]/contact/embed/page.tsx
@@ -3,7 +3,6 @@ import ContactForm from '@/components/contact/ContactForm';
 import { getContactCopy } from '@/components/contact/contactCopy';
 import { normalizeLocale } from '@/lib/i18n';
 import { getContactLocale } from '@/lib/contact';
-import { isContactPublishedLocale } from '@/lib/publishedLocales';
 import { getBuildLocaleCodes } from '@/lib/siteRouting';
 
 export async function generateMetadata({
@@ -13,7 +12,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { lang } = await params;
   const locale = normalizeLocale(lang);
-  const copy = getContactCopy(locale);
+  const copy = getContactCopy(getContactLocale(locale));
   return {
     title: `${copy.title} | FastGPT`,
     description: copy.subtitle,
@@ -54,9 +53,7 @@ export default async function LocalizedContactEmbedPage({
 }
 
 export function generateStaticParams() {
-  return getBuildLocaleCodes()
-    .filter(isContactPublishedLocale)
-    .map((lang) => ({ lang }));
+  return getBuildLocaleCodes().map((lang) => ({ lang }));
 }
 
 export const dynamicParams = false;

--- a/src/app/[lang]/contact/page.tsx
+++ b/src/app/[lang]/contact/page.tsx
@@ -2,9 +2,10 @@ import type { Metadata } from 'next';
 import ContactPage from '@/components/contact/ContactPage';
 import { getContactCopy } from '@/components/contact/contactCopy';
 import { getAlternates } from '@/lib/seo';
+import { getContactLocale } from '@/lib/contact';
 import { getDictionary, normalizeLocale } from '@/lib/i18n';
 import { getBuildLocaleCodes } from '@/lib/siteRouting';
-import { contactPublishedLocaleCodes, isContactPublishedLocale } from '@/lib/publishedLocales';
+import { contactPublishedLocaleCodes } from '@/lib/publishedLocales';
 
 export async function generateMetadata({
   params
@@ -13,11 +14,14 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { lang } = await params;
   const locale = normalizeLocale(lang);
-  const copy = getContactCopy(locale);
+  const contactLocale = getContactLocale(locale);
+  const copy = getContactCopy(contactLocale);
   return {
     title: `${copy.title} | FastGPT`,
     description: copy.subtitle,
-    alternates: getAlternates(locale, '/contact', contactPublishedLocaleCodes)
+    alternates: getAlternates(contactLocale, '/contact', contactPublishedLocaleCodes),
+    robots:
+      locale === contactLocale ? { index: true, follow: true } : { index: false, follow: true }
   };
 }
 
@@ -32,9 +36,7 @@ export default async function LocalizedContactPage({
 }
 
 export function generateStaticParams() {
-  return getBuildLocaleCodes()
-    .filter(isContactPublishedLocale)
-    .map((lang) => ({ lang }));
+  return getBuildLocaleCodes().map((lang) => ({ lang }));
 }
 
 export const dynamicParams = false;

--- a/src/components/contact/ContactPage.tsx
+++ b/src/components/contact/ContactPage.tsx
@@ -182,7 +182,7 @@ export default function ContactPage({
           <div className="relative mx-auto flex max-w-6xl flex-col items-center text-center">
             <h1
               data-hero-reveal
-              className="m-0 w-full max-w-6xl text-balance font-semibold leading-[0.98] tracking-[-0.055em] text-ink"
+              className="m-0 w-full max-w-6xl text-center text-balance whitespace-pre-line font-semibold leading-[0.98] tracking-[-0.055em] text-ink"
               style={{ fontSize: 'clamp(3rem, 6vw, 5.75rem)' }}
             >
               {copy.hero.title}

--- a/src/components/contact/ContactPage.tsx
+++ b/src/components/contact/ContactPage.tsx
@@ -182,7 +182,7 @@ export default function ContactPage({
           <div className="relative mx-auto flex max-w-6xl flex-col items-center text-center">
             <h1
               data-hero-reveal
-              className="m-0 w-full max-w-6xl text-center text-balance whitespace-pre-line font-semibold leading-[0.98] tracking-[-0.055em] text-ink"
+              className="m-0 w-full max-w-6xl text-center text-balance whitespace-pre-line font-semibold leading-[1.06] tracking-[-0.055em] text-ink"
               style={{ fontSize: 'clamp(3rem, 6vw, 5.75rem)' }}
             >
               {copy.hero.title}

--- a/src/components/contact/contactCopy.ts
+++ b/src/components/contact/contactCopy.ts
@@ -290,7 +290,7 @@ export type ContactExperienceCopy = {
 const zhExperience: ContactExperienceCopy = {
   nav: { home: '返回首页', sales: '商务咨询' },
   hero: {
-    title: '把复杂的 AI 落地，交给真正懂业务的团队',
+    title: '把复杂的 AI 落地\n交给真正懂业务的团队',
     body: '从需求诊断、架构设计到 POC 验证与生产交付，让每一步都围绕真实业务价值推进。',
     primaryAction: '开始咨询',
     secondaryAction: '了解 FastGPT'

--- a/src/components/home/BrandWall.tsx
+++ b/src/components/home/BrandWall.tsx
@@ -101,7 +101,7 @@ export default function BrandWall({ t }: { t: BrandWallT }) {
         <m.div
           initial={{ opacity: 0, y: 24 }}
           whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, margin: '0px 0px 120px 0px' }}
+          viewport={{ once: true, margin: '0px 0px 48px 0px' }}
           transition={{ duration: 0.6, delay: 0.15, ease: [0.21, 0.47, 0.32, 0.98] }}
           className="max-w-[min(92vw,1300px)] md:max-w-[min(85vw,1300px)] mx-auto py-6 md:py-10 lg:py-20"
         >

--- a/src/components/home/BrandWall.tsx
+++ b/src/components/home/BrandWall.tsx
@@ -102,7 +102,7 @@ export default function BrandWall({ t }: { t: BrandWallT }) {
           initial={{ opacity: 0, y: 24 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true, margin: '0px 0px 48px 0px' }}
-          transition={{ duration: 0.6, delay: 0.15, ease: [0.21, 0.47, 0.32, 0.98] }}
+          transition={{ duration: 0.8, delay: 0.15, ease: [0.21, 0.47, 0.32, 0.98] }}
           className="max-w-[min(92vw,1300px)] md:max-w-[min(85vw,1300px)] mx-auto py-6 md:py-10 lg:py-20"
         >
           <div className="grid grid-cols-4 sm:grid-cols-5 md:grid-cols-7 lg:grid-cols-8 gap-3 md:gap-3 lg:gap-3">

--- a/src/components/home/BrandWall.tsx
+++ b/src/components/home/BrandWall.tsx
@@ -101,8 +101,8 @@ export default function BrandWall({ t }: { t: BrandWallT }) {
         <m.div
           initial={{ opacity: 0, y: 24 }}
           whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, margin: '-80px' }}
-          transition={{ duration: 0.8, delay: 0.5, ease: [0.21, 0.47, 0.32, 0.98] }}
+          viewport={{ once: true, margin: '0px 0px 120px 0px' }}
+          transition={{ duration: 0.6, delay: 0.15, ease: [0.21, 0.47, 0.32, 0.98] }}
           className="max-w-[min(92vw,1300px)] md:max-w-[min(85vw,1300px)] mx-auto py-6 md:py-10 lg:py-20"
         >
           <div className="grid grid-cols-4 sm:grid-cols-5 md:grid-cols-7 lg:grid-cols-8 gap-3 md:gap-3 lg:gap-3">

--- a/src/components/home/CTA.tsx
+++ b/src/components/home/CTA.tsx
@@ -68,7 +68,7 @@ export default function CTA({ t, locale }: { t: CTAT; locale: string }) {
                 <m.h2
                   initial={{ opacity: 0, y: 20 }}
                   whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true, margin: '0px 0px 120px 0px' }}
+                  viewport={{ once: true, margin: '0px 0px 48px 0px' }}
                   transition={{ duration: 0.7, ease: [0.21, 0.47, 0.32, 0.98] }}
                   className="m-0 text-ink text-[22px] md:text-[36px] font-semibold leading-[30px] md:leading-[48px] tracking-[-0.44px] md:tracking-[-0.72px]"
                 >
@@ -79,7 +79,7 @@ export default function CTA({ t, locale }: { t: CTAT; locale: string }) {
                 <m.p
                   initial={{ opacity: 0, y: 15 }}
                   whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true, margin: '0px 0px 120px 0px' }}
+                  viewport={{ once: true, margin: '0px 0px 48px 0px' }}
                   transition={{ duration: 0.6, delay: 0.08 }}
                   className="m-0 text-ink-sub text-[16px] md:text-[20px] font-normal leading-[26px] md:leading-[32px] tracking-[-0.16px] md:tracking-[-0.2px]"
                 >
@@ -90,7 +90,7 @@ export default function CTA({ t, locale }: { t: CTAT; locale: string }) {
               <m.div
                 initial={{ opacity: 0, y: 15 }}
                 whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true, margin: '0px 0px 120px 0px' }}
+                viewport={{ once: true, margin: '0px 0px 48px 0px' }}
                 transition={{ duration: 0.6, delay: 0.15 }}
                 className="flex flex-col md:flex-row items-stretch md:items-center gap-3 md:gap-8 w-full"
               >

--- a/src/components/home/CTA.tsx
+++ b/src/components/home/CTA.tsx
@@ -68,7 +68,7 @@ export default function CTA({ t, locale }: { t: CTAT; locale: string }) {
                 <m.h2
                   initial={{ opacity: 0, y: 20 }}
                   whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true, margin: '-80px' }}
+                  viewport={{ once: true, margin: '0px 0px 120px 0px' }}
                   transition={{ duration: 0.7, ease: [0.21, 0.47, 0.32, 0.98] }}
                   className="m-0 text-ink text-[22px] md:text-[36px] font-semibold leading-[30px] md:leading-[48px] tracking-[-0.44px] md:tracking-[-0.72px]"
                 >
@@ -79,8 +79,8 @@ export default function CTA({ t, locale }: { t: CTAT; locale: string }) {
                 <m.p
                   initial={{ opacity: 0, y: 15 }}
                   whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true, margin: '-80px' }}
-                  transition={{ duration: 0.6, delay: 0.15 }}
+                  viewport={{ once: true, margin: '0px 0px 120px 0px' }}
+                  transition={{ duration: 0.6, delay: 0.08 }}
                   className="m-0 text-ink-sub text-[16px] md:text-[20px] font-normal leading-[26px] md:leading-[32px] tracking-[-0.16px] md:tracking-[-0.2px]"
                 >
                   {t.subtitle}
@@ -90,8 +90,8 @@ export default function CTA({ t, locale }: { t: CTAT; locale: string }) {
               <m.div
                 initial={{ opacity: 0, y: 15 }}
                 whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true, margin: '-80px' }}
-                transition={{ duration: 0.6, delay: 0.3 }}
+                viewport={{ once: true, margin: '0px 0px 120px 0px' }}
+                transition={{ duration: 0.6, delay: 0.15 }}
                 className="flex flex-col md:flex-row items-stretch md:items-center gap-3 md:gap-8 w-full"
               >
                 <m.a

--- a/src/components/home/CaseStudies.tsx
+++ b/src/components/home/CaseStudies.tsx
@@ -86,6 +86,7 @@ export default function CaseStudies({ t, locale }: { t: CasesT; locale: string }
   const isDraggingRef = useRef(false);
   const dragStartClientX = useRef(0);
   const dragStartVal = useRef(0);
+  const [isMobile, setIsMobile] = useState(false);
   const caseAssets = getCasesAssets(locale);
   const imageByCaseKey: Record<string, string> = {
     cetc: caseAssets.cetc,
@@ -110,6 +111,14 @@ export default function CaseStudies({ t, locale }: { t: CasesT; locale: string }
     const id = setInterval(next, 3500);
     return () => clearInterval(id);
   }, [isPaused, next]);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 767px)');
+    const update = () => setIsMobile(mq.matches);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
 
   const MAX_DRAG = 700;
 
@@ -180,7 +189,6 @@ export default function CaseStudies({ t, locale }: { t: CasesT; locale: string }
                 const isCenter = offset === 0;
                 const isAdjacent = Math.abs(offset) === 1;
                 const isVisible = isCenter || isAdjacent;
-                const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
                 const baseX = isMobile ? offset * 340 : offset * 660;
                 return (
                   <m.div

--- a/src/components/home/CaseStudies.tsx
+++ b/src/components/home/CaseStudies.tsx
@@ -148,7 +148,7 @@ export default function CaseStudies({ t, locale }: { t: CasesT; locale: string }
       <div className="max-w-[min(92vw,1300px)] md:max-w-[min(85vw,1300px)] mx-auto flex flex-col gap-8 md:gap-12">
         <SectionHeader badge={t.badge} title={t.title} subtitle={t.subtitle} />
 
-        <FadeIn delay={0.5}>
+        <FadeIn delay={0.15}>
           <div
             className="relative select-none"
             style={{ cursor: 'grab' }}

--- a/src/components/home/FAQ.tsx
+++ b/src/components/home/FAQ.tsx
@@ -102,7 +102,7 @@ export default function FAQ({ t }: { t: FaqT }) {
           )}
         </FadeIn>
 
-        <FadeIn delay={0.5}>
+        <FadeIn delay={0.15}>
           <div className="flex flex-col" style={{ rowGap: 24 }}>
             <div className="bg-white" style={{ padding: '0 16px' }}>
               {t.items.map((item, i) => (

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -41,15 +41,7 @@ const mobileBlobs = [
 
 export default function Hero({ stars: initialStars, locale, t, children }: HeroProps) {
   const containerRef = useRef<HTMLElement>(null);
-  const [isMobile, setIsMobile] = useState(false);
   const [isDesktop, setIsDesktop] = useState(false);
-  useEffect(() => {
-    const mq = window.matchMedia('(max-width: 767px)');
-    queueMicrotask(() => setIsMobile(mq.matches));
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
-  }, []);
   useEffect(() => {
     const mq = window.matchMedia('(min-width: 1024px)');
     queueMicrotask(() => setIsDesktop(mq.matches));
@@ -215,7 +207,10 @@ export default function Hero({ stars: initialStars, locale, t, children }: HeroP
             style={{ perspective: 1900 }}
           >
             <m.div
-              style={isMobile ? {} : { rotateX, scale, y: offsetY, transformStyle: 'preserve-3d' }}
+              // Avoid applying the desktop transform during the mobile
+              // hydration frame, where it can push the dashboard over the
+              // second CTA before the viewport query has resolved.
+              style={isDesktop ? { rotateX, scale, y: offsetY, transformStyle: 'preserve-3d' } : {}}
               className="hero-image-fade origin-bottom"
             >
               <Image

--- a/src/components/home/ProductHighlights.tsx
+++ b/src/components/home/ProductHighlights.tsx
@@ -30,7 +30,7 @@ export default function ProductHighlights({ t }: { t: ProductHighlightsT }) {
         <SectionHeader badge={t.badge} title={t.title} subtitle={t.subtitle} />
 
         <div className="w-full">
-          <StaggerContainer className="grid grid-cols-1 sm:grid-cols-2 gap-[16px]" initialDelay={0.5}>
+          <StaggerContainer className="grid grid-cols-1 sm:grid-cols-2 gap-[16px]" initialDelay={0.15}>
             {features.slice(0, 2).map(({ key, title, desc, image }) => (
               <StaggerItem key={key}>
                 <FeatureCard title={title} desc={desc} image={image} tall />
@@ -38,7 +38,7 @@ export default function ProductHighlights({ t }: { t: ProductHighlightsT }) {
             ))}
           </StaggerContainer>
 
-          <StaggerContainer className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-[16px] mt-[16px]" initialDelay={0.8}>
+          <StaggerContainer className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-[16px] mt-[16px]" initialDelay={0.2}>
             {features.slice(2).map(({ key, title, desc, image }, i) => (
               <StaggerItem key={key} className={i === features.slice(2).length - 1 ? 'sm:col-span-2 lg:col-span-1' : ''}>
                 <FeatureCard title={title} desc={desc} image={image} />

--- a/src/components/home/Services.tsx
+++ b/src/components/home/Services.tsx
@@ -37,7 +37,7 @@ export default function Services({ t }: { t: ServicesT }) {
         </div>
 
         <div className="py-[80px] px-[16px] md:p-0">
-          <StaggerContainer className="grid grid-cols-2 gap-[32px] md:gap-[60px_24px]" initialDelay={0.5}>
+          <StaggerContainer className="grid grid-cols-2 gap-[32px] md:gap-[60px_24px]" initialDelay={0.15}>
             {services.map((s) => (
               <StaggerItem key={s.title}>
                 <m.div

--- a/src/components/home/Solutions.tsx
+++ b/src/components/home/Solutions.tsx
@@ -66,7 +66,7 @@ export default function Solutions({ t, locale }: { t: SolutionsT; locale: string
         </div>
 
         {/* Desktop (lg+): tabs with active pill + image + CTA */}
-        <FadeIn delay={0.5} className="hidden lg:block">
+        <FadeIn delay={0.15} className="hidden lg:block">
           <div className="flex justify-center mb-12 overflow-x-auto no-scrollbar">
             <div
               className="inline-flex items-center"
@@ -200,7 +200,7 @@ export default function Solutions({ t, locale }: { t: SolutionsT; locale: string
         </FadeIn>
 
         {/* Mobile/Tablet: no tabs, no CTA. One featured solution per tab */}
-        <FadeIn delay={0.5} className="lg:hidden">
+        <FadeIn delay={0.15} className="lg:hidden">
           <div className="flex flex-col gap-12">
             {tabs.map((tab) => {
               const item = tab.items[0];

--- a/src/components/home/Stats.tsx
+++ b/src/components/home/Stats.tsx
@@ -27,7 +27,7 @@ function useCountUp(end: number, decimals = 0, duration = 2000) {
           requestAnimationFrame(animate);
         }
       },
-      { rootMargin: '0px 0px 120px 0px', threshold: 0.1 }
+      { rootMargin: '0px 0px 48px 0px', threshold: 0.1 }
     );
     observer.observe(el);
     return () => observer.disconnect();
@@ -86,7 +86,7 @@ function StatItem({
       ref={ref}
       initial={{ opacity: 0, y: 30 }}
       whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: '0px 0px 120px 0px' }}
+      viewport={{ once: true, margin: '0px 0px 48px 0px' }}
       transition={{ duration: 0.7, delay, ease: [0.21, 0.47, 0.32, 0.98] }}
       className="flex flex-1 flex-col items-center text-center"
       style={{ rowGap: 24 }}

--- a/src/components/home/Stats.tsx
+++ b/src/components/home/Stats.tsx
@@ -27,7 +27,7 @@ function useCountUp(end: number, decimals = 0, duration = 2000) {
           requestAnimationFrame(animate);
         }
       },
-      { threshold: 0.3 }
+      { rootMargin: '0px 0px 120px 0px', threshold: 0.1 }
     );
     observer.observe(el);
     return () => observer.disconnect();
@@ -86,7 +86,7 @@ function StatItem({
       ref={ref}
       initial={{ opacity: 0, y: 30 }}
       whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: '-60px' }}
+      viewport={{ once: true, margin: '0px 0px 120px 0px' }}
       transition={{ duration: 0.7, delay, ease: [0.21, 0.47, 0.32, 0.98] }}
       className="flex flex-1 flex-col items-center text-center"
       style={{ rowGap: 24 }}

--- a/src/components/home/motion/FadeIn.tsx
+++ b/src/components/home/motion/FadeIn.tsx
@@ -22,7 +22,7 @@ export default function FadeIn({
   children,
   direction = 'up',
   delay = 0,
-  duration = 0.6,
+  duration = 0.7,
   distance = 30,
   once = true,
   className,

--- a/src/components/home/motion/FadeIn.tsx
+++ b/src/components/home/motion/FadeIn.tsx
@@ -60,7 +60,7 @@ export default function FadeIn({
       style={style}
       initial="hidden"
       whileInView="visible"
-      viewport={{ once, margin: '0px 0px 120px 0px' }}
+      viewport={{ once, margin: '0px 0px 48px 0px' }}
       variants={variants}
     >
       {children}

--- a/src/components/home/motion/FadeIn.tsx
+++ b/src/components/home/motion/FadeIn.tsx
@@ -22,7 +22,7 @@ export default function FadeIn({
   children,
   direction = 'up',
   delay = 0,
-  duration = 0.7,
+  duration = 0.6,
   distance = 30,
   once = true,
   className,
@@ -52,13 +52,15 @@ export default function FadeIn({
 
   const MotionTag = m[as] as typeof m.div;
 
+  // Start slightly before the element reaches the viewport. A negative
+  // margin made fast scrolls reveal the section before its animation ran.
   return (
     <MotionTag
       className={className}
       style={style}
       initial="hidden"
       whileInView="visible"
-      viewport={{ once, margin: '-80px' }}
+      viewport={{ once, margin: '0px 0px 120px 0px' }}
       variants={variants}
     >
       {children}

--- a/src/components/home/motion/Stagger.tsx
+++ b/src/components/home/motion/Stagger.tsx
@@ -36,7 +36,7 @@ export function StaggerContainer({
       className={className}
       initial="hidden"
       whileInView="visible"
-      viewport={{ once, margin: '0px 0px 120px 0px' }}
+      viewport={{ once, margin: '0px 0px 48px 0px' }}
       variants={variants}
     >
       {children}

--- a/src/components/home/motion/Stagger.tsx
+++ b/src/components/home/motion/Stagger.tsx
@@ -15,7 +15,7 @@ interface StaggerProps {
 export function StaggerContainer({
   children,
   className,
-  staggerDelay = 0.08,
+  staggerDelay = 0.06,
   initialDelay = 0,
   once = true
 }: StaggerProps) {
@@ -29,12 +29,14 @@ export function StaggerContainer({
     }
   };
 
+  // Prewarm the stagger before the grid reaches the viewport so its first
+  // item is visible when the user arrives at the section.
   return (
     <m.div
       className={className}
       initial="hidden"
       whileInView="visible"
-      viewport={{ once, margin: '-60px' }}
+      viewport={{ once, margin: '0px 0px 120px 0px' }}
       variants={variants}
     >
       {children}


### PR DESCRIPTION
## What changed

- Wrap the Chinese Contact hero headline into the intended two-line layout.
- Publish the Contact fallback routes and related verification updates.
- Start homepage scroll animations before sections enter the viewport.
- Reduce accumulated section delays and stagger intervals across the homepage.
- Align CTA child animations and start Stats count-up earlier.

## Why

Homepage sections were rendered with conservative negative viewport margins and 0.5–0.8 second delays. During normal or fast scrolling, content could enter the viewport before its animation started, making the page feel late or blank. The Contact hero also needed a controlled Chinese line break.

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `git diff --check`
- Local dev homepage returned HTTP 200
- Existing Contact page build and verification checks were run before this follow-up commit
