### PR TITLE
ci: optimize GitHub image release pipeline

### DIFF
--- a/.github/workflows/fastgpt-home-image.yml
+++ b/.github/workflows/fastgpt-home-image.yml
@@ -7,7 +7,9 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  IMAGE_NAME: ghcr.io/${{ github.repository }}
+  # Production must always deploy the upstream package, even when this workflow
+  # is inspected or dispatched from a fork.
+  IMAGE_NAME: ghcr.io/labring/fastgpt-home
 
 jobs:
   build-fastgpt-landingpage-images:
@@ -57,12 +59,14 @@ jobs:
         run: test -n "$NEXT_PUBLIC_CRM_API_URL"
 
       - name: Build and push Docker image to GitHub Container Registry
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           file: Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             NEXT_PUBLIC_BAIDU_TONGJI=${{ secrets.NEXT_PUBLIC_BAIDU_TONGJI }}
             NEXT_PUBLIC_BAIDU_KEY=${{ secrets.NEXT_PUBLIC_BAIDU_KEY }}
@@ -79,8 +83,19 @@ jobs:
             NEXT_PUBLIC_ATTRIBUTION_COOKIE_DOMAIN=.fastgpt.cn
             NEXT_PUBLIC_ATTRIBUTION_STORAGE_MODE=${{ vars.NEXT_PUBLIC_ATTRIBUTION_STORAGE_MODE }}
             NEXT_PUBLIC_ATTRIBUTION_SOURCE=${{ secrets.NEXT_PUBLIC_ATTRIBUTION_SOURCE }}
-      - uses: actions-hub/kubectl@master
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.30.0
+
+      - name: Roll out the published GitHub Container Registry image
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: set image deployment/fastgpt-home fastgpt-home=${{ env.IMAGE_NAME }}:${{ steps.datetime.outputs.datetime }}
+          IMAGE: ${{ env.IMAGE_NAME }}:${{ steps.datetime.outputs.datetime }}
+        run: |
+          test -n "$KUBE_CONFIG" || { echo 'KUBE_CONFIG is required'; exit 1; }
+          kubeconfig="$RUNNER_TEMP/kubeconfig"
+          printf '%s' "$KUBE_CONFIG" > "$kubeconfig"
+          KUBECONFIG="$kubeconfig" kubectl config view --minify >/dev/null
+          KUBECONFIG="$kubeconfig" kubectl set image deployment/fastgpt-home fastgpt-home="$IMAGE"
+          KUBECONFIG="$kubeconfig" kubectl rollout status deployment/fastgpt-home --timeout=5m

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,14 +41,17 @@ ENV NEXT_PUBLIC_ATTRIBUTION_SOURCE=$NEXT_PUBLIC_ATTRIBUTION_SOURCE
 
 RUN test "$NEXT_PUBLIC_SITE_VARIANT" = "cn" || (echo "Docker publication supports only NEXT_PUBLIC_SITE_VARIANT=cn" >&2; exit 1)
 
-# copy packages and one project
+# Install dependencies in a reusable layer. Source changes should not invalidate
+# the dependency layer, and npm ci keeps the published build aligned with the lockfile.
+COPY package.json package-lock.json ./
+RUN npm ci --no-audit --no-fund
+
 COPY . ./
 
 # Replace URLs in files (fix sed -i syntax for Alpine Linux)
 RUN find . -type f -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" -o -name "*.json" | xargs grep -l "https://doc.fastgpt.io" | xargs -r sed -i "s#https://doc.fastgpt.io#https://doc.fastgpt.cn#g"
 RUN find . -type f -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" -o -name "*.json" | xargs grep -l "https://cloud.fastgpt.io" | xargs -r sed -i "s#https://cloud.fastgpt.io#https://cloud.fastgpt.cn#g"
 
-RUN npm install
 RUN npm run build
 
 FROM fholzer/nginx-brotli:latest


### PR DESCRIPTION
## What changed

- Pin the production image target to `ghcr.io/labring/fastgpt-home` so a fork context cannot redirect production deployment to a fork package.
- Enable GitHub Actions BuildKit cache for the Docker publish job.
- Use a cached `npm ci` dependency layer in the Dockerfile.
- Replace the unpinned `actions-hub/kubectl@master` step with `azure/setup-kubectl@v4`, kubeconfig validation, and rollout verification.

## Why

The release workflow already publishes to GHCR, but the image name was derived from the triggering repository and the deployment action was an unpinned third-party action. This makes the production target less explicit and leaves build time on the table. The CI and Dockerfile contain no Aliyun registry references after this change.

## Validation

- Workflow YAML parsed successfully.
- `docker buildx build --check --file Dockerfile .` passed.
- `npm ci --ignore-scripts --dry-run --no-audit --no-fund` passed.
- `git diff --check` passed.