### PR TITLE
fix: restore release dependency installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,17 +41,14 @@ ENV NEXT_PUBLIC_ATTRIBUTION_SOURCE=$NEXT_PUBLIC_ATTRIBUTION_SOURCE
 
 RUN test "$NEXT_PUBLIC_SITE_VARIANT" = "cn" || (echo "Docker publication supports only NEXT_PUBLIC_SITE_VARIANT=cn" >&2; exit 1)
 
-# Install dependencies in a reusable layer. Source changes should not invalidate
-# the dependency layer, and npm ci keeps the published build aligned with the lockfile.
-COPY package.json package-lock.json ./
-RUN npm ci --no-audit --no-fund
-
+# copy packages and one project
 COPY . ./
 
 # Replace URLs in files (fix sed -i syntax for Alpine Linux)
 RUN find . -type f -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" -o -name "*.json" | xargs grep -l "https://doc.fastgpt.io" | xargs -r sed -i "s#https://doc.fastgpt.io#https://doc.fastgpt.cn#g"
 RUN find . -type f -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" -o -name "*.json" | xargs grep -l "https://cloud.fastgpt.io" | xargs -r sed -i "s#https://cloud.fastgpt.io#https://cloud.fastgpt.cn#g"
 
+RUN npm install
 RUN npm run build
 
 FROM fholzer/nginx-brotli:latest


### PR DESCRIPTION
## Root cause

The merged release CI change replaced `npm install` with `npm ci` in `Dockerfile`. The repository has `legacy-peer-deps=true` in `.npmrc`; the dependency-only layer did not copy that file, so the container ran strict peer resolution and failed on `@heroui/theme@2.4.26` versus Tailwind CSS 3.4.19.

## Fix

Restore the original Dockerfile installation sequence so the build copies the repository, reads `.npmrc`, and runs `npm install`. No other CI or application files are changed.

## Verification

- `docker buildx build --check --file Dockerfile .` passed.
- Full `docker buildx build` passed, including `npm install`, Next.js static export, and final `nginx -t`.
- `git diff --check` passed.