### PR TITLE
fix: restore kubectl release credential handling

### DIFF
--- a/.github/workflows/fastgpt-home-image.yml
+++ b/.github/workflows/fastgpt-home-image.yml
@@ -95,7 +95,34 @@ jobs:
         run: |
           test -n "$KUBE_CONFIG" || { echo 'KUBE_CONFIG is required'; exit 1; }
           kubeconfig="$RUNNER_TEMP/kubeconfig"
-          printf '%s' "$KUBE_CONFIG" > "$kubeconfig"
+          KUBE_RAW="$KUBE_CONFIG" KUBE_OUTPUT="$kubeconfig" node - <<'NODE'
+          const fs = require('node:fs');
+
+          const raw = String(process.env.KUBE_RAW || '');
+          if (!raw.trim()) throw new Error('KUBE_CONFIG is empty');
+
+          let value = raw.trim();
+          try {
+            const parsed = JSON.parse(value);
+            value = typeof parsed === 'string' ? parsed : JSON.stringify(parsed);
+          } catch {}
+
+          if (!value.includes('\n') && /\\n/.test(value)) {
+            value = value.replace(/\\r?\\n/g, '\n').replace(/\\"/g, '"');
+          }
+
+          const looksLikeConfig = (text) => /["']?apiVersion["']?\s*:/i.test(text);
+          if (!looksLikeConfig(value)) {
+            const compact = value.replace(/\s+/g, '');
+            if (/^[A-Za-z0-9+/]+={0,2}$/.test(compact) && compact.length > 32) {
+              const decoded = Buffer.from(compact, 'base64').toString('utf8');
+              if (looksLikeConfig(decoded)) value = decoded;
+            }
+          }
+
+          if (!looksLikeConfig(value)) throw new Error('KUBE_CONFIG format unsupported');
+          fs.writeFileSync(process.env.KUBE_OUTPUT, value.endsWith('\n') ? value : `${value}\n`, { mode: 0o600 });
+          NODE
           KUBECONFIG="$kubeconfig" kubectl config view --minify >/dev/null
           KUBECONFIG="$kubeconfig" kubectl set image deployment/fastgpt-home fastgpt-home="$IMAGE"
           KUBECONFIG="$kubeconfig" kubectl rollout status deployment/fastgpt-home --timeout=5m

--- a/.github/workflows/fastgpt-home-image.yml
+++ b/.github/workflows/fastgpt-home-image.yml
@@ -83,46 +83,8 @@ jobs:
             NEXT_PUBLIC_ATTRIBUTION_COOKIE_DOMAIN=.fastgpt.cn
             NEXT_PUBLIC_ATTRIBUTION_STORAGE_MODE=${{ vars.NEXT_PUBLIC_ATTRIBUTION_STORAGE_MODE }}
             NEXT_PUBLIC_ATTRIBUTION_SOURCE=${{ secrets.NEXT_PUBLIC_ATTRIBUTION_SOURCE }}
-      - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
-        with:
-          version: v1.30.0
-
-      - name: Roll out the published GitHub Container Registry image
+      - uses: actions-hub/kubectl@master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-          IMAGE: ${{ env.IMAGE_NAME }}:${{ steps.datetime.outputs.datetime }}
-        run: |
-          test -n "$KUBE_CONFIG" || { echo 'KUBE_CONFIG is required'; exit 1; }
-          kubeconfig="$RUNNER_TEMP/kubeconfig"
-          KUBE_RAW="$KUBE_CONFIG" KUBE_OUTPUT="$kubeconfig" node - <<'NODE'
-          const fs = require('node:fs');
-
-          const raw = String(process.env.KUBE_RAW || '');
-          if (!raw.trim()) throw new Error('KUBE_CONFIG is empty');
-
-          let value = raw.trim();
-          try {
-            const parsed = JSON.parse(value);
-            value = typeof parsed === 'string' ? parsed : JSON.stringify(parsed);
-          } catch {}
-
-          if (!value.includes('\n') && /\\n/.test(value)) {
-            value = value.replace(/\\r?\\n/g, '\n').replace(/\\"/g, '"');
-          }
-
-          const looksLikeConfig = (text) => /["']?apiVersion["']?\s*:/i.test(text);
-          if (!looksLikeConfig(value)) {
-            const compact = value.replace(/\s+/g, '');
-            if (/^[A-Za-z0-9+/]+={0,2}$/.test(compact) && compact.length > 32) {
-              const decoded = Buffer.from(compact, 'base64').toString('utf8');
-              if (looksLikeConfig(decoded)) value = decoded;
-            }
-          }
-
-          if (!looksLikeConfig(value)) throw new Error('KUBE_CONFIG format unsupported');
-          fs.writeFileSync(process.env.KUBE_OUTPUT, value.endsWith('\n') ? value : `${value}\n`, { mode: 0o600 });
-          NODE
-          KUBECONFIG="$kubeconfig" kubectl config view --minify >/dev/null
-          KUBECONFIG="$kubeconfig" kubectl set image deployment/fastgpt-home fastgpt-home="$IMAGE"
-          KUBECONFIG="$kubeconfig" kubectl rollout status deployment/fastgpt-home --timeout=5m
+        with:
+          args: set image deployment/fastgpt-home fastgpt-home=${{ env.IMAGE_NAME }}:${{ steps.datetime.outputs.datetime }}


### PR DESCRIPTION
## Root cause

The failed production run built and pushed the image successfully, then failed during rollout because the release workflow replaced `actions-hub/kubectl@master` with a manual kubectl invocation. The existing `KUBE_CONFIG` secret is base64-encoded, and the previous action decoded it automatically. The manual step wrote the encoded value directly to the kubeconfig file.

## Fix

Restore the existing `actions-hub/kubectl@master` deployment step, which already handles the repository's `KUBE_CONFIG` format. This removes the unnecessary custom decoder and keeps the fix to the smallest possible workflow change.

## Verification

- Workflow YAML parsing passed.
- `git diff --check` passed.
- Confirmed the action's entrypoint decodes `KUBE_CONFIG` with `base64 -d`.
- PR preview build passed before this simplification; the production rollout step will be exercised after merge.