### PR TITLE
fix: keep locale fallback on current domain

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -2,6 +2,14 @@ map_hash_bucket_size 256;
 map_hash_max_size 16384;
 include /etc/nginx/generated-redirects.conf;
 
+# If a locale-prefixed page is not published on this host, serve the same route
+# in the site's default language without changing the browser URL.
+map $uri $locale_fallback_path {
+  default "/__missing_locale_fallback__";
+  ~^/[A-Za-z][A-Za-z](?:-[A-Za-z]+)?/?$ "/";
+  ~^/[A-Za-z][A-Za-z](?:-[A-Za-z]+)?(/.*)$ $1;
+}
+
 server {
   listen 80;
   server_name localhost;
@@ -30,14 +38,14 @@ server {
       add_header Cache-Control "public, max-age=3600, stale-while-revalidate=86400";
       add_header X-Cache-Status "HIT-CONTACT";
       include /etc/nginx/embeddable-security-headers.conf;
-      try_files $uri $uri.html $uri/ =404;
+      try_files $uri $uri.html $locale_fallback_path $locale_fallback_path.html $locale_fallback_path/ $uri/ =404;
   }
 
   location ~ ^/(?:contact/embed|(?:en|zh|zh-hant)/contact/embed)$ {
       add_header Cache-Control "public, max-age=3600, stale-while-revalidate=86400";
       add_header X-Cache-Status "HIT-CONTACT-EMBED";
       include /etc/nginx/embeddable-security-headers.conf;
-      try_files $uri $uri.html $uri/ =404;
+      try_files $uri $uri.html $locale_fallback_path $locale_fallback_path.html $locale_fallback_path/ $uri/ =404;
   }
 
   # Strip trailing slashes — Next.js uses trailingSlash: false,
@@ -124,7 +132,7 @@ server {
       add_header Cache-Control "public, max-age=3600, stale-while-revalidate=86400";
       add_header X-Cache-Status "HIT-HTML";
       include /etc/nginx/security-headers.conf;
-      try_files $uri $uri.html $uri/ =404;
+      try_files $uri $uri.html $locale_fallback_path $locale_fallback_path.html $locale_fallback_path/ $uri/ =404;
   }
 
   # This is necessary when `trailingSlash: false`.

--- a/scripts/lib/redirects.js
+++ b/scripts/lib/redirects.js
@@ -1,7 +1,5 @@
 const fs = require('node:fs');
 const path = require('node:path');
-const { getLocaleOwner, getProductionBaseUrls, localeCodes } = require('./site-variant');
-
 const EN_ROUTE_REGISTRY = path.join('src', 'faq', 'generated-en-route-registry.json');
 
 function readObjectKeys(rootDir, relativePath, variableName) {
@@ -213,79 +211,13 @@ function addFaqAliasRedirect(redirects, prefix, entry) {
   }
 }
 
-function buildRedirects(rootDir, env = process.env) {
-  const { cn: cnUrl, io: ioUrl } = getProductionBaseUrls(env);
-  const { chinese: chineseFaqIds, english: englishFaqIds } = getPublishedFaqIds(rootDir);
+function buildRedirects(rootDir) {
   const faqProjection = getFaqRedirectProjection(rootDir);
-  const compareSlugs = fs
-    .readdirSync(path.join(rootDir, 'content', 'competitors', 'en'))
-    .filter((file) => file.endsWith('.md'))
-    .map((file) => file.replace(/\.md$/, ''));
-  const techIdentities = getTechIdentities(rootDir);
   const ioRedirects = new Map();
   const cnRedirects = new Map();
 
-  for (const pagePath of ['', '/price']) {
-    addRedirect(ioRedirects, `/zh${pagePath}`, `${cnUrl}${pagePath || '/'}`);
-    addRedirect(cnRedirects, `/zh${pagePath}`, `${cnUrl}${pagePath || '/'}`);
-
-    for (const locale of localeCodes.filter((locale) => locale !== 'zh')) {
-      const source = `/${locale}${pagePath}`;
-      const targetPath = locale === 'en' ? pagePath || '/' : `/${locale}${pagePath}`;
-      addRedirect(cnRedirects, source, `${ioUrl}${targetPath}`);
-      if (locale === 'en') addRedirect(ioRedirects, source, `${ioUrl}${targetPath}`);
-    }
-  }
-
-  addRedirect(ioRedirects, '/zh/contact', `${cnUrl}/contact`);
-  addRedirect(ioRedirects, '/en/contact', `${ioUrl}/contact`);
-  addRedirect(cnRedirects, '/zh/contact', `${cnUrl}/contact`);
-  addRedirect(cnRedirects, '/en/contact', `${ioUrl}/contact`);
-  addRedirect(cnRedirects, '/zh-hant/contact', `${ioUrl}/zh-hant/contact`);
-
-  addRedirect(ioRedirects, '/zh/enterprise', `${cnUrl}/`);
-  addRedirect(cnRedirects, '/zh/enterprise', `${cnUrl}/`);
-
-  for (const [sourcePrefix, targetUrl, ids, redirects] of [
-    ['/zh/faq', cnUrl, chineseFaqIds, ioRedirects],
-    ['/en/faq', ioUrl, englishFaqIds, ioRedirects],
-    ['/zh/faq', cnUrl, chineseFaqIds, cnRedirects],
-    ['/en/faq', ioUrl, englishFaqIds, cnRedirects]
-  ]) {
-    addRedirect(redirects, sourcePrefix, `${targetUrl}/faq`);
-    for (const id of ids) {
-      const encodedId = encodeURIComponent(id);
-      const target = `${targetUrl}/faq/${encodedId}`;
-      addRedirect(redirects, `${sourcePrefix}/${encodedId}`, target);
-      if (encodedId !== id) addRedirect(redirects, `${sourcePrefix}/${id}`, target);
-    }
-  }
-
   for (const entry of faqProjection.eligible) {
     addFaqAliasRedirect(ioRedirects, '/faq', entry);
-    addFaqAliasRedirect(ioRedirects, '/en/faq', entry);
-    addFaqAliasRedirect(cnRedirects, '/en/faq', entry);
-  }
-
-  for (const [sourcePrefix, targetUrl, redirects] of [
-    ['/zh/compare', cnUrl, ioRedirects],
-    ['/en/compare', ioUrl, ioRedirects],
-    ['/zh/compare', cnUrl, cnRedirects],
-    ['/en/compare', ioUrl, cnRedirects]
-  ]) {
-    addRedirect(redirects, sourcePrefix, `${targetUrl}/compare`);
-    for (const slug of compareSlugs) {
-      addRedirect(redirects, `${sourcePrefix}/${slug}`, `${targetUrl}/compare/${slug}`);
-    }
-  }
-
-  addRedirect(ioRedirects, '/zh/tech-center', `${cnUrl}/tech-center`);
-  addRedirect(cnRedirects, '/zh/tech-center', `${cnUrl}/tech-center`);
-  for (const identity of techIdentities) {
-    if (getLocaleOwner(identity.locale) !== 'cn') continue;
-    const targetUrl = `${cnUrl}${identity.canonicalPath}`;
-    addRedirect(ioRedirects, identity.sourcePath, targetUrl);
-    addRedirect(cnRedirects, identity.sourcePath, targetUrl);
   }
 
   return { cnRedirects, ioRedirects };
@@ -305,7 +237,15 @@ export default {
       return Response.redirect(redirectUrl, 301);
     }
 
-    const response = await env.ASSETS.fetch(request);
+    let response = await env.ASSETS.fetch(request);
+    if (response.status === 404) {
+      const match = url.pathname.match(/^\\/[a-z]{2}(?:-[a-z]{2,8})?(?=\\/|$)(.*)$/i);
+      if (match) {
+        const fallbackUrl = new URL(url);
+        fallbackUrl.pathname = match[1] || '/';
+        response = await env.ASSETS.fetch(new Request(fallbackUrl, request));
+      }
+    }
     ${
       noindex
         ? `const headers = new Headers(response.headers);

--- a/scripts/verify-faq-redirects.js
+++ b/scripts/verify-faq-redirects.js
@@ -127,7 +127,7 @@ function verifyArtifacts(projection) {
   const variant = resolveSiteVariant();
   assert(['io', 'cn'].includes(variant), `Redirect artifact mode requires io or cn, received ${variant}`);
   const redirects = variant === 'io' ? parseWorkerRedirects() : parseNginxRedirects();
-  const prefixes = variant === 'io' ? ['/faq', '/en/faq'] : ['/en/faq'];
+  const prefixes = variant === 'io' ? ['/faq'] : [];
 
   for (const entry of projection.eligible) {
     for (const prefix of prefixes) {
@@ -142,7 +142,7 @@ function verifyArtifacts(projection) {
   }
 
   for (const sourceSlug of projection.deniedSources) {
-    for (const prefix of ['/faq', '/en/faq']) {
+    for (const prefix of prefixes) {
       for (const sourcePath of encodedPathVariants(prefix, sourceSlug)) {
         assert(!redirects.has(sourcePath), `Denied source was emitted: ${sourcePath}`);
       }

--- a/scripts/verify-i18n-seo.js
+++ b/scripts/verify-i18n-seo.js
@@ -20,7 +20,6 @@ const variant = resolveSiteVariant();
 const defaultLocale = getDefaultLocale(variant);
 const baseUrls = getProductionBaseUrls();
 const baseUrl = getCanonicalBaseUrl(variant);
-const encodedFaqId = 'why-is-few-shot-learning-useful';
 const techPath = '/tutorial/private-deployment-topology';
 const compareSlugs = [
   'dify-vs-fastgpt',
@@ -190,29 +189,12 @@ function parseNginxRedirects() {
   return parseNginxRedirectMap(read('.next/nginx-redirects.conf'));
 }
 
-function verifyFaqRedirects(redirects, prefix, targetBaseUrl, ids) {
-  for (const id of ids) {
-    const encodedId = encodeURIComponent(id);
-    assert.equal(
-      redirects.get(`${prefix}/${encodedId}`),
-      `${targetBaseUrl}/faq/${encodedId}`,
-      `Missing redirect for ${prefix}/${encodedId}`
-    );
-  }
-}
-
 function verifyRedirects() {
   assert(!fs.existsSync(path.join(outDir, '_redirects')), 'Legacy Cloudflare redirects were exported');
 
   const nginxRedirects = parseNginxRedirects();
-  const faqIds = getPublishedFaqIds(rootDir);
   if (variant === 'cn') {
-    assert.equal(nginxRedirects.get('/ja/price'), 'https://fastgpt.io/ja/price');
-    assert.equal(nginxRedirects.get(`/zh${techPath}`), `https://fastgpt.cn${techPath}`);
-    assert(!nginxRedirects.has('/ja/faq'), 'Nginx redirects an unpublished Japanese FAQ');
-    assert(!nginxRedirects.has('/ja/contact'), 'Nginx redirects an unpublished Japanese Contact');
-    verifyFaqRedirects(nginxRedirects, '/zh/faq', baseUrls.cn, faqIds.chinese);
-    verifyFaqRedirects(nginxRedirects, '/en/faq', baseUrls.io, faqIds.english);
+    assert.equal(nginxRedirects.size, 0, 'CN build contains cross-domain locale redirects');
     return;
   }
 
@@ -225,20 +207,15 @@ function verifyRedirects() {
     return;
   }
 
-  assert.equal(redirects.get('/zh'), 'https://fastgpt.cn/');
-  assert.equal(redirects.get(`/zh/faq/${faqId}`), `https://fastgpt.cn/faq/${faqId}`);
-  assert.equal(
-    redirects.get(`/zh/faq/${encodedFaqId}`),
-    `https://fastgpt.cn/faq/${encodedFaqId}`
-  );
-  assert.equal(redirects.get('/zh/tech-center'), 'https://fastgpt.cn/tech-center');
-  assert.equal(redirects.get(`/zh${techPath}`), `https://fastgpt.cn${techPath}`);
-  assert.equal(redirects.get('/en'), 'https://fastgpt.io/');
+  assert(!redirects.has('/zh'), 'Worker redirects /zh to another domain');
+  assert(!redirects.has('/en'), 'Worker redirects /en to another domain');
+  assert(!redirects.has(`/zh/faq/${faqId}`), 'Worker redirects a locale-prefixed FAQ');
+  assert(!redirects.has('/zh/tech-center'), 'Worker redirects a locale-prefixed tech center');
+  assert(!redirects.has(`/zh${techPath}`), 'Worker redirects a locale-prefixed article');
   assert(!redirects.has('/zh/faq/not-published'), 'Worker redirects an unpublished FAQ');
   assert(!redirects.has('/ja/faq'), 'Worker redirects an unpublished Japanese FAQ');
   assert(!redirects.has('/ja/contact'), 'Worker redirects an unpublished Japanese Contact');
-  verifyFaqRedirects(redirects, '/zh/faq', baseUrls.cn, faqIds.chinese);
-  verifyFaqRedirects(redirects, '/en/faq', baseUrls.io, faqIds.english);
+  assert(worker.includes('fallbackUrl.pathname = match[1] || \'/\''));
 }
 
 function verifySitemap() {

--- a/scripts/verify-p0.js
+++ b/scripts/verify-p0.js
@@ -1,6 +1,7 @@
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
+const vm = require('node:vm');
 const sharp = require('sharp');
 const { getPublishedFaqIds } = require('./lib/redirects');
 const { getCanonicalBaseUrl, resolveSiteVariant } = require('./lib/site-variant');
@@ -146,6 +147,16 @@ function verifyNginxHeaders() {
     nginxConfig.includes('return 301 $locale_redirect_target$is_args$args;'),
     'Nginx must preserve query parameters on canonical redirects'
   );
+  assert(
+    nginxConfig.includes('$locale_fallback_path'),
+    'Nginx must internally fall back locale-prefixed routes'
+  );
+  assert(
+    nginxConfig.includes(
+      'try_files $uri $uri.html $locale_fallback_path $locale_fallback_path.html $locale_fallback_path/ $uri/ =404;'
+    ),
+    'Nginx locale fallback must run before a locale asset directory can redirect'
+  );
   assert(nginxConfig.includes('map_hash_bucket_size 256;'), 'Nginx map hash bucket is too small');
   assert(nginxConfig.includes('map_hash_max_size 16384;'), 'Nginx map hash table is too small');
   assert(
@@ -172,15 +183,13 @@ function verifyNginxHeaders() {
 
   const redirectMap = fs.readFileSync(path.join(rootDir, '.next', 'nginx-redirects.conf'), 'utf8');
   if (variant === 'cn') {
-    assert(redirectMap.includes('"/zh" "https://fastgpt.cn/";'));
-    assert(redirectMap.includes(`"/en/faq/${faqId}" "https://fastgpt.io/faq/${faqId}";`));
-    assert(!redirectMap.includes('"/ja/faq"'), 'Nginx redirects an unpublished locale page');
+    assert(!redirectMap.includes('"https://'), 'CN build contains cross-domain locale redirects');
   } else {
     assert(!redirectMap.includes('"https://'), `${variant} build contains Nginx redirects`);
   }
 }
 
-function verifyCloudflareRedirects() {
+async function verifyCloudflareRedirects() {
   assert(!fs.existsSync(path.join(outDir, '_redirects')), 'Legacy Cloudflare redirects were exported');
   if (variant === 'cn') return;
 
@@ -189,15 +198,39 @@ function verifyCloudflareRedirects() {
     assert(worker.includes('new Map([])'), 'Preview worker contains redirect rules');
     assert(worker.includes("X-Robots-Tag', 'noindex, nofollow"));
   } else {
-    assert(worker.includes(`/zh/faq/${faqId}`));
-    assert(worker.includes(`https://fastgpt.cn/faq/${faqId}`));
+    assert(!worker.includes(`https://fastgpt.cn/faq/${faqId}`));
+    assert(worker.includes("fallbackUrl.pathname = match[1] || '/';"));
   }
+
+  const context = { Headers, Map, Request, Response, URL };
+  vm.runInNewContext(worker.replace('export default', 'globalThis.worker ='), context);
+  const requests = [];
+  const response = await context.worker.fetch(
+    new Request(`${baseUrl}/zh/price?source=locale-fallback-test`),
+    {
+      ASSETS: {
+        async fetch(request) {
+          const url = new URL(request.url);
+          requests.push(`${url.pathname}${url.search}`);
+          return url.pathname === '/price'
+            ? new Response('default language', { status: 200 })
+            : new Response('missing', { status: 404 });
+        }
+      }
+    }
+  );
+  assert.equal(response.status, 200, 'Worker did not serve the default-language route');
+  assert.equal(await response.text(), 'default language');
+  assert.deepEqual(requests, [
+    '/zh/price?source=locale-fallback-test',
+    '/price?source=locale-fallback-test'
+  ]);
 }
 
 async function main() {
   await verifyImage();
   verifyNginxHeaders();
-  verifyCloudflareRedirects();
+  await verifyCloudflareRedirects();
 
   verifyFaqPage('/faq');
   verifyFaqPage(`/faq/${faqId}`);

--- a/scripts/verify-technical-export.js
+++ b/scripts/verify-technical-export.js
@@ -123,23 +123,12 @@ function verifySitemap(outDir, variant, canonicalUrls, reviewPaths, baseUrls) {
   }
 }
 
-function verifyNginxRedirects(nextDir, variant, identities, baseUrls) {
+function verifyNginxRedirects(nextDir, variant) {
   const redirects = readNginxRedirects(nextDir);
-  if (variant === 'preview' || variant === 'io') {
-    assert.equal(redirects.size, 0, `${variant} export contains Nginx redirects`);
-    return;
-  }
-
-  for (const identity of identities) {
-    assert.equal(
-      redirects.get(identity.sourcePath),
-      `${baseUrls.cn}${identity.canonicalPath}`,
-      `CN redirect does not resolve ${identity.sourcePath}`
-    );
-  }
+  assert.equal(redirects.size, 0, `${variant} export contains locale redirects`);
 }
 
-function verifyWorkerRedirects(outDir, variant, identities, baseUrls) {
+function verifyWorkerRedirects(outDir, variant, identities) {
   if (variant === 'cn') return;
 
   const { redirects, source } = readWorkerRedirects(outDir);
@@ -148,20 +137,9 @@ function verifyWorkerRedirects(outDir, variant, identities, baseUrls) {
     return;
   }
 
-  assert(
-    source.includes('redirectUrl.search = url.search'),
-    'Worker does not preserve query strings'
-  );
-  assert(
-    source.includes('Response.redirect(redirectUrl, 301)'),
-    'Worker does not emit 301 redirects'
-  );
+  assert(source.includes("fallbackUrl.pathname = match[1] || '/'"));
   for (const identity of identities) {
-    assert.equal(
-      redirects.get(identity.sourcePath),
-      `${baseUrls.cn}${identity.canonicalPath}`,
-      `IO redirect does not resolve ${identity.sourcePath}`
-    );
+    assert(!redirects.has(identity.sourcePath), `IO Worker redirects ${identity.sourcePath}`);
   }
 }
 
@@ -229,8 +207,8 @@ function verifyTechnicalExport({
   }
 
   verifySitemap(outDir, variant, canonicalUrls, reviewPaths, baseUrls);
-  verifyNginxRedirects(nextDir, variant, identities, baseUrls);
-  verifyWorkerRedirects(outDir, variant, identities, baseUrls);
+  verifyNginxRedirects(nextDir, variant);
+  verifyWorkerRedirects(outDir, variant, identities);
 
   return { count: identities.length, variant };
 }

--- a/scripts/verify-technical-export.test.js
+++ b/scripts/verify-technical-export.test.js
@@ -34,7 +34,6 @@ test('technical export verifier accepts a complete China projection', () => {
   try {
     const identities = getTechIdentities(root);
     const sitemap = [];
-    const redirects = new Map();
     for (const identity of identities) {
       const canonical = `${baseUrls.cn}${identity.canonicalPath}`;
       const routePath = path.join(outDir, `${identity.canonicalPath.slice(1)}.html`);
@@ -44,12 +43,11 @@ test('technical export verifier accepts a complete China projection', () => {
         `<link rel="canonical" href="${canonical}"><meta name="robots" content="index, follow"><script>{"url":"${canonical}"}</script>`
       );
       sitemap.push(`<url><loc>${canonical}</loc></url>`);
-      redirects.set(identity.sourcePath, canonical);
     }
 
     fs.writeFileSync(path.join(outDir, 'sitemap.xml'), `<urlset>${sitemap.join('')}</urlset>`);
     writeCloudflareWorker(outDir, new Map(), false);
-    writeNginxRedirectMap(nextDir, redirects);
+    writeNginxRedirectMap(nextDir, new Map());
 
     assert.deepEqual(
       verifyTechnicalExport({


### PR DESCRIPTION
## Summary

- remove cross-domain redirects for locale-prefixed routes such as /zh and /en
- serve the current site default-language route internally when a locale-prefixed page is unavailable
- align FAQ, i18n, P0, and technical-export regression checks with the no-redirect behavior

## Verification

- NEXT_PUBLIC_SITE_VARIANT=io NEXT_PUBLIC_HOME_URL=https://fastgpt.io npm run build
- npm run verify:release-regression
- npm run verify:technical-export-regression
- NEXT_PUBLIC_SITE_VARIANT=io NEXT_PUBLIC_HOME_URL=https://fastgpt.io npm run verify:p0
- NEXT_PUBLIC_SITE_VARIANT=io NEXT_PUBLIC_HOME_URL=https://fastgpt.io npm run verify:faq-redirects
- nginx configuration and live fallback requests verified with nginx:alpine