### PR TITLE
feat: add static FastGPT learning center

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,11 +104,13 @@
     "verify:customers-data": "node scripts/verify-customers-data.js",
     "verify:customers-search": "node scripts/verify-customers-search.js",
     "verify:customers-export": "node scripts/verify-customers-export.js",
-    "verify:llms": "node scripts/verify-llms.js"
+    "verify:llms": "node scripts/verify-llms.js",
+    "verify:learning-center": "node scripts/verify-learning-center.js"
   },
   "dependencies": {
     "@heroui/react": "^2.8.9",
     "@heroui/theme": "^2.4.26",
+    "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-slot": "^1.0.2",
     "@tailwindcss/typography": "^0.5.20",
     "autoprefixer": "^10.4.24",

--- a/scripts/verify-learning-center.js
+++ b/scripts/verify-learning-center.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const sourcePath = path.join(__dirname, '..', 'src/components/learning-center/LearningCenterPage.tsx');
+const source = fs.readFileSync(sourcePath, 'utf8');
+const urls = [...source.matchAll(/url:\s*["']([^"']+)["']/g)].map((match) => match[1]);
+const duplicates = urls.filter((url, index) => urls.indexOf(url) !== index);
+const forbidden = urls.filter(
+  (url) =>
+    /canva\.com\/design\/[^/]+\/[^/]+\/edit(?:[/?#]|$)/i.test(url) ||
+    /^https?:\/\/(?:www\.)?(?:douyin|xiaohongshu|zhihu)\.com\/?$/i.test(url)
+);
+
+if (duplicates.length) {
+  throw new Error(`Learning center contains duplicate URLs: ${[...new Set(duplicates)].join(', ')}`);
+}
+
+if (forbidden.length) {
+  throw new Error(`Learning center contains unstable or platform-home URLs: ${forbidden.join(', ')}`);
+}
+
+console.log(`Learning center verification passed (${urls.length} links).`);

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -45,6 +45,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
     }
   }
 
+  if (currentSiteVariant === 'cn') {
+    addEntry(getOwnedLocaleUrl('zh', '/videos'));
+  }
+
   for (const locale of contactPublishedLocaleCodes.filter((locale) =>
     siteLocales.includes(locale)
   )) {

--- a/src/app/videos/page.tsx
+++ b/src/app/videos/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import LearningCenterPage from '@/components/learning-center/LearningCenterPage';
+import { getDictionary } from '@/lib/i18n';
+import { currentSiteVariant, getOwnedLocaleUrl } from '@/lib/siteRouting';
+
+const title = 'FastGPT 学习中心';
+const description =
+  '从入门到精通，系统化学习 FastGPT 的使用技巧、部署方案和最佳实践。所有教程均由官方团队精心制作。';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const canonical = getOwnedLocaleUrl('zh', '/videos');
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: { title, description, type: 'website', url: canonical }
+  };
+}
+
+export default async function VideosPage() {
+  if (currentSiteVariant === 'io') notFound();
+  const dict = await getDictionary('zh');
+
+  return (
+    <LearningCenterPage
+      locale="zh"
+      navLinks={dict.links}
+      navCta={dict.Home.navCta}
+      footer={dict.Home.footer}
+    />
+  );
+}

--- a/src/components/home/Footer.tsx
+++ b/src/components/home/Footer.tsx
@@ -82,8 +82,8 @@ function buildColumns(t: FooterT['columns'], locale?: string): Column[] {
         },
         {
           label: t.links.items.learning,
-          href: 'https://video.fastgpt.cn/videos',
-          external: true
+          href: normalizedLocale === 'zh' ? '/videos' : 'https://video.fastgpt.cn/videos',
+          external: normalizedLocale !== 'zh'
         },
         {
           label: t.links.items.cases,

--- a/src/components/home/Navbar.tsx
+++ b/src/components/home/Navbar.tsx
@@ -32,7 +32,7 @@ function isExternalHref(href: string) {
 }
 
 function getNavLinkRybbitAttrs(link: NavLink) {
-  if (link.href.includes('video.fastgpt.cn/videos')) {
+  if (link.href === '/videos' || link.href.includes('video.fastgpt.cn/videos')) {
     return rybbitClickAttrs(RYBBIT_EVENTS.learningCenterClick, 'home_nav_learning_center');
   }
 
@@ -52,6 +52,7 @@ export default function Navbar({
   publishedLocales,
   reviewLocalePaths = false,
   consultHref,
+  consultationTrigger = true,
   onConsultClick
 }: {
   links?: NavLink[];
@@ -61,6 +62,7 @@ export default function Navbar({
   publishedLocales?: readonly LocaleCode[];
   reviewLocalePaths?: boolean;
   consultHref?: string;
+  consultationTrigger?: boolean;
   onConsultClick?: () => void;
 }) {
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -232,6 +234,7 @@ export default function Navbar({
             )}
             <a
               href={contactUrl}
+              data-consultation-trigger={consultationTrigger || undefined}
               onClick={onConsultClick}
               {...rybbitClickAttrs(RYBBIT_EVENTS.businessConsultClick, 'home_nav_consult')}
               aria-label={t.consult}
@@ -363,6 +366,7 @@ export default function Navbar({
             <div className="flex flex-col gap-3 mt-6 pt-6 border-t border-hairline-soft">
               <a
                 href={contactUrl}
+                data-consultation-trigger={consultationTrigger || undefined}
                 {...rybbitClickAttrs(
                   RYBBIT_EVENTS.businessConsultClick,
                   'home_nav_mobile_menu_consult'

--- a/src/components/learning-center/LearningCenterPage.module.css
+++ b/src/components/learning-center/LearningCenterPage.module.css
@@ -1,0 +1,504 @@
+.page {
+  --surface: #ffffff;
+  --surface-muted: #f8fafc;
+  --line: #e2e8f0;
+  --ink: #0f172a;
+  --muted: #475569;
+  --blue: #2563eb;
+  min-height: 100vh;
+  overflow-x: hidden;
+  background: var(--surface);
+  color: var(--ink);
+  font-family: 'Inter', 'PingFang SC', 'Microsoft YaHei', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+}
+
+.main {
+  padding-top: 64px;
+  background: linear-gradient(rgba(15, 23, 42, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(15, 23, 42, 0.025) 1px, transparent 1px), var(--surface);
+  background-size: 56px 56px;
+}
+
+.container {
+  width: min(100%, 1200px);
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+.hero {
+  padding: 90px 0 56px;
+  border-bottom: 1px solid var(--line);
+  background: radial-gradient(circle at 50% 0, rgba(59, 130, 246, 0.1), transparent 38%),
+    var(--surface);
+  text-align: center;
+}
+
+.heroBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 24px;
+  padding: 6px 12px;
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.07);
+  color: var(--blue);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.heroBadgeDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--blue);
+}
+
+.hero h1 {
+  margin: 0 0 18px;
+  color: var(--ink);
+  font-size: clamp(36px, 5vw, 56px);
+  font-weight: 700;
+  letter-spacing: -0.035em;
+  line-height: 1.1;
+}
+
+.hero p {
+  max-width: 620px;
+  margin: 0 auto;
+  color: var(--muted);
+  font-size: 17px;
+  line-height: 1.7;
+}
+
+.heroActions {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 32px;
+}
+
+.primaryCta,
+.secondaryCta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  padding: 0 18px;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.primaryCta {
+  border: 1px solid #161616;
+  background: #161616;
+  color: #fff;
+}
+
+.secondaryCta {
+  border: 1px solid var(--line);
+  background: #fff;
+  color: var(--ink);
+}
+
+.primaryCta:hover,
+.secondaryCta:hover {
+  transform: translateY(-1px);
+}
+
+.primaryCta:hover {
+  background: #333;
+}
+
+.secondaryCta:hover {
+  border-color: #94a3b8;
+}
+
+.announcement {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 32px 0;
+  padding: 14px 18px;
+  border: 1px solid #fde68a;
+  border-radius: 8px;
+  background: #fffbeb;
+  color: #92400e;
+  font-size: 14px;
+}
+
+.featuredSection {
+  margin: 44px 0 56px;
+}
+
+.featuredTitle {
+  margin: 0 0 18px;
+  color: var(--ink);
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.featuredGrid,
+.videoGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.featuredCard,
+.videoCard {
+  display: block;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: inherit;
+  text-decoration: none;
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.featuredCard:hover,
+.videoCard:hover {
+  border-color: #bfdbfe;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  transform: translateY(-2px);
+}
+
+.featuredThumb,
+.videoThumb {
+  position: relative;
+  height: 184px;
+  overflow: hidden;
+  background: #eff6ff;
+}
+
+.videoThumb {
+  height: 170px;
+}
+
+.docThumb {
+  background: #f1f5f9;
+}
+
+.featuredOverlay,
+.videoPlayOverlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(15, 23, 42, 0.08);
+  opacity: 0;
+  transition: opacity 160ms ease;
+}
+
+.featuredCard:hover .featuredOverlay,
+.videoCard:hover .videoPlayOverlay {
+  opacity: 1;
+}
+
+.featuredPlayBtn,
+.videoPlayBtn {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.94);
+  color: var(--ink);
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.14);
+}
+
+.featuredInfo,
+.videoInfo {
+  padding: 18px;
+}
+
+.featuredInfo h3,
+.videoInfo h3 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 16px;
+  font-weight: 650;
+  line-height: 1.45;
+}
+
+.featuredInfo p,
+.videoDesc {
+  display: -webkit-box;
+  overflow: hidden;
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.6;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.videoCategories {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 22px;
+}
+
+.videoCatBtn {
+  min-height: 34px;
+  padding: 0 14px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: #fff;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  transition: color 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.videoCatBtn:hover,
+.videoCatBtn.active {
+  border-color: #93c5fd;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.videoInfoMeta {
+  margin-top: 14px;
+}
+
+.videoLevel {
+  display: inline-flex;
+  min-height: 24px;
+  align-items: center;
+  padding: 0 8px;
+  border-radius: 4px;
+  background: #f1f5f9;
+  color: #475569;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.levelBeginner {
+  background: #ecfdf5;
+  color: #047857;
+}
+.levelIntermediate {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+.levelAdvanced {
+  background: #fff7ed;
+  color: #c2410c;
+}
+
+.emptyState {
+  grid-column: 1 / -1;
+  padding: 72px 20px;
+  border: 1px dashed var(--line);
+  border-radius: 8px;
+  background: var(--surface-muted);
+  text-align: center;
+}
+
+.emptyStateIcon {
+  color: #94a3b8;
+}
+
+.emptyStateText {
+  margin-top: 12px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.codeCover {
+  position: relative;
+  display: flex;
+  height: 100%;
+  min-height: 184px;
+  flex-direction: column;
+  justify-content: space-between;
+  overflow: hidden;
+  padding: 18px;
+  background: #172554;
+  color: #fff;
+}
+
+.codeCoverCompact {
+  min-height: 170px;
+}
+
+.codeCoverDocument {
+  background: #334155;
+}
+
+.codeCoverGrid {
+  position: absolute;
+  inset: 0;
+  opacity: 0.16;
+  background-image: linear-gradient(rgba(255, 255, 255, 0.45) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.45) 1px, transparent 1px);
+  background-size: 22px 22px;
+}
+
+.codeCoverArc {
+  position: absolute;
+  top: -58px;
+  right: -28px;
+  width: 170px;
+  height: 170px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 50%;
+}
+
+.codeCoverTop,
+.codeCoverBody,
+.codeCoverFooter {
+  position: relative;
+  z-index: 1;
+}
+
+.codeCoverTop,
+.codeCoverFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.codeCoverBrand {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.codeCoverBrand img {
+  display: block;
+}
+
+.codeCoverFormat,
+.codeCoverFooter {
+  color: rgba(255, 255, 255, 0.68);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.codeCoverBody {
+  margin: auto 0;
+  padding: 16px 0;
+}
+
+.codeCoverSeries {
+  color: #bfdbfe;
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.codeCoverBody h4 {
+  max-width: 92%;
+  margin: 8px 0 0;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.35;
+}
+
+.codeCoverIndex {
+  color: #fff;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.leadCta {
+  margin-top: 64px;
+  padding: 0 0 72px;
+}
+
+.leadCtaInner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 30px 32px;
+  border: 1px solid #bfdbfe;
+  border-radius: 8px;
+  background: #eff6ff;
+}
+
+.leadCtaEyebrow {
+  color: #2563eb;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.leadCta h2 {
+  margin: 8px 0 0;
+  color: var(--ink);
+  font-size: 24px;
+  line-height: 1.3;
+}
+
+.leadCta p {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+@media (max-width: 900px) {
+  .featuredGrid,
+  .videoGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .main {
+    padding-top: 64px;
+  }
+
+  .container {
+    padding: 0 20px;
+  }
+
+  .hero {
+    padding: 64px 0 42px;
+  }
+
+  .hero p {
+    font-size: 15px;
+  }
+
+  .heroActions {
+    flex-direction: column;
+    align-items: stretch;
+    margin-top: 24px;
+  }
+
+  .featuredGrid,
+  .videoGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .featuredSection {
+    margin: 32px 0 42px;
+  }
+
+  .leadCtaInner {
+    align-items: stretch;
+    flex-direction: column;
+    padding: 24px 20px;
+  }
+
+  .leadCta {
+    margin-top: 48px;
+    padding-bottom: 48px;
+  }
+}

--- a/src/components/learning-center/LearningCenterPage.tsx
+++ b/src/components/learning-center/LearningCenterPage.tsx
@@ -1,0 +1,824 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import type { ComponentProps } from 'react';
+import Navbar from '@/components/home/Navbar';
+import Footer from '@/components/home/Footer';
+import HomeThemeFix from '@/components/home/HomeThemeFix';
+import { useContactUrl } from '@/components/home/hooks/useContactUrl';
+import { RYBBIT_EVENTS, rybbitClickAttrs } from '@/lib/rybbitEvents';
+import styles from './LearningCenterPage.module.css';
+
+type HomeFooter = ComponentProps<typeof Footer>['t'];
+type NavLink = { label: string; href: string };
+type NavCta = { trial: string; consult: string };
+
+interface Video {
+  _id?: string;
+  title: string;
+  desc: string;
+  url: string;
+  level: 'beginner' | 'intermediate' | 'advanced';
+  category:
+    | 'beginner-tutorial'
+    | 'technical-tutorial'
+    | 'deployment'
+    | 'feature-intro'
+    | 'operations'
+    | 'industry-cases'
+    | 'customer-cases';
+  series?: string;
+  type?: 'doc';
+  featured?: boolean;
+}
+
+interface Announcement {
+  content: string;
+  enabled: boolean;
+}
+
+interface Settings {
+  heroTitle: string;
+  heroDescription: string;
+  heroBadge: string;
+}
+
+const categoryLabels: Record<Video['category'], string> = {
+  'beginner-tutorial': '新手教学',
+  'technical-tutorial': '技术教程',
+  deployment: '部署教程',
+  'feature-intro': '功能介绍',
+  operations: '基础运维',
+  'industry-cases': '行业案例',
+  'customer-cases': '客户案例'
+};
+
+function VideoCover({ video, compact = false }: { video: Video; compact?: boolean }) {
+  const label = video.series || categoryLabels[video.category];
+  const format = video.type === 'doc' ? '官方文档' : '学习中心';
+  const seriesIndex = video.series?.match(/·\s*(\d+)$/)?.[1];
+
+  return (
+    <div
+      className={`${styles.codeCover} ${compact ? styles.codeCoverCompact : ''} ${
+        video.type === 'doc' ? styles.codeCoverDocument : ''
+      }`}
+      role="img"
+      aria-label={`${label}：${video.title}`}
+    >
+      <span className={styles.codeCoverGrid} aria-hidden="true" />
+      <span className={styles.codeCoverArc} aria-hidden="true" />
+      <div className={styles.codeCoverTop}>
+        <span className={styles.codeCoverBrand}>
+          <Image src="/logo-nav.svg" alt="" width={22} height={22} />
+          <span>FastGPT</span>
+        </span>
+        <span className={styles.codeCoverFormat}>{format}</span>
+      </div>
+      <div className={styles.codeCoverBody}>
+        <span className={styles.codeCoverSeries}>{label}</span>
+        <h4>{video.title}</h4>
+      </div>
+      <div className={styles.codeCoverFooter}>
+        <span>FASTGPT LEARNING CENTER</span>
+        {seriesIndex ? <span className={styles.codeCoverIndex}>{seriesIndex}</span> : null}
+      </div>
+    </div>
+  );
+}
+
+export const staticVideos: Video[] = [
+  // ========== 新手教学 ==========
+  {
+    title: 'FastGPT 全平台操作手册',
+    desc: '完整的 FastGPT 使用手册，涵盖所有功能模块的详细操作说明和配置指南。',
+    url: 'https://fael3z0zfze.feishu.cn/wiki/TRsDwq96LiWvFRktDj3cJffNntb',
+    level: 'beginner',
+    category: 'beginner-tutorial',
+    type: 'doc'
+  },
+  {
+    title: '新手教程',
+    desc: '专为新手用户打造的快速入门教程，带你从零开始掌握 FastGPT 的核心功能。',
+    url: 'https://fael3z0zfze.feishu.cn/wiki/BxwqwfRzDimhQbke04mcFzqInAF',
+    level: 'beginner',
+    category: 'beginner-tutorial',
+    type: 'doc'
+  },
+
+  // ========== 技术教学教程 - 知识库模块 ==========
+  {
+    title: '知识库模块01-通用知识库',
+    desc: '学习如何创建和管理 FastGPT 的通用知识库，掌握知识库的基础配置与数据导入方法。',
+    url: 'https://www.bilibili.com/video/BV1Xfcmz3EA5/',
+    level: 'beginner',
+    category: 'technical-tutorial',
+    series: '知识库 · 01'
+  },
+  {
+    title: '知识库模块02-web知识库',
+    desc: '深入了解 FastGPT 的 Web 知识库功能，学习如何爬取和管理网页内容作为知识来源。',
+    url: 'https://www.bilibili.com/video/BV1P7cUzFEMo/',
+    level: 'beginner',
+    category: 'technical-tutorial',
+    series: '知识库 · 02'
+  },
+  {
+    title: '知识库模块03-标签/权限设置',
+    desc: '掌握知识库的标签分类和权限管理，实现多用户协作和精细化的访问控制。',
+    url: 'https://www.bilibili.com/video/BV1sLcUzhEij/',
+    level: 'intermediate',
+    category: 'technical-tutorial',
+    series: '知识库 · 03'
+  },
+
+  // ========== 技术教学教程 - Agent搭建模块 ==========
+  {
+    title: 'Agent搭建模块01-对话Agent',
+    desc: '从零开始搭建你的第一个对话 Agent，了解对话流程设计和参数配置的基础知识。',
+    url: 'https://www.bilibili.com/video/BV1nucQzwEKh/',
+    level: 'beginner',
+    category: 'technical-tutorial',
+    series: 'Agent搭建 · 01'
+  },
+  {
+    title: 'Agent搭建模块02-工作流',
+    desc: '学习如何使用 FastGPT 的工作流编排功能，构建复杂的多步骤 AI 应用。',
+    url: 'https://www.bilibili.com/video/BV1aycDzEEbV/',
+    level: 'intermediate',
+    category: 'technical-tutorial',
+    series: 'Agent搭建 · 02'
+  },
+  {
+    title: 'Agent搭建模块03-发布',
+    desc: '了解如何发布和分享你的 Agent，包括 API 接口、网页嵌入和多渠道分发。',
+    url: 'https://www.bilibili.com/video/BV1ezcDzQEBZ/',
+    level: 'intermediate',
+    category: 'technical-tutorial',
+    series: 'Agent搭建 · 03'
+  },
+  {
+    title: '知识库搜索节点',
+    desc: '详细讲解知识库搜索节点的使用方法，包括搜索策略、相似度设置和结果优化技巧。',
+    url: 'https://www.bilibili.com/video/BV1ZywQzcEbN/',
+    level: 'intermediate',
+    category: 'technical-tutorial'
+  },
+  {
+    title: '问题分类节点',
+    desc: '学习使用问题分类节点实现智能路由，根据用户意图自动分发到不同的处理流程。',
+    url: 'https://www.bilibili.com/video/BV1uwwXzSE5T/',
+    level: 'intermediate',
+    category: 'technical-tutorial'
+  },
+
+  // ========== 部署教程 ==========
+  {
+    title: 'FastGPT商业版命令行部署教程',
+    desc: '完整的命令行部署指南，从服务器配置到服务启动，快速完成 FastGPT 商业版的部署。',
+    url: 'https://www.bilibili.com/video/BV1voPVzxEBV/',
+    level: 'beginner',
+    category: 'deployment',
+    series: '部署 · 01'
+  },
+  {
+    title: 'FastGPT模型配置教程视频',
+    desc: '学习如何配置和管理 FastGPT 的 AI 模型，包括多模型切换、参数调优和成本控制。',
+    url: 'https://www.bilibili.com/video/BV1FLAoznE69/',
+    level: 'intermediate',
+    category: 'deployment',
+    series: '部署 · 03'
+  },
+
+  // ========== 功能介绍 ==========
+  {
+    title: '数据统计查看',
+    desc: '了解 FastGPT 的数据统计功能，掌握如何查看使用量、消费统计和用户行为分析数据。',
+    url: 'https://www.bilibili.com/video/BV1RyPjzwEHb/',
+    level: 'intermediate',
+    category: 'feature-intro'
+  },
+  {
+    title: '知识库导入',
+    desc: '学习多种知识库导入方式，包括文本、文档、网页和 API 导入的详细操作流程。',
+    url: 'https://www.bilibili.com/video/BV1aTPjz4Eej/',
+    level: 'beginner',
+    category: 'feature-intro'
+  },
+  {
+    title: 'MCP配置使用',
+    desc: '深入了解 MCP (Model Context Protocol) 的配置和使用方法，提升模型的上下文理解能力。',
+    url: 'https://www.bilibili.com/video/BV1tZPzzDEQb/',
+    level: 'advanced',
+    category: 'feature-intro'
+  },
+  {
+    title: '智能体调试技巧',
+    desc: '掌握智能体开发中的调试技巧，包括日志查看、错误排查和性能优化方法。',
+    url: 'https://www.bilibili.com/video/BV1iPPrziE6J/',
+    level: 'intermediate',
+    category: 'feature-intro'
+  },
+  {
+    title: '知识库参数设置',
+    desc: '详细讲解知识库的各项参数配置，优化检索效果和问答质量。',
+    url: 'https://www.bilibili.com/video/BV1msPCzfEBQ/',
+    level: 'intermediate',
+    category: 'feature-intro'
+  },
+  {
+    title: '权限分配管理操作',
+    desc: '学习如何进行团队协作和权限管理，包括角色分配、资源共享和访问控制。',
+    url: 'https://www.bilibili.com/video/BV1SaPSzEEod/',
+    level: 'intermediate',
+    category: 'feature-intro'
+  },
+
+  // ========== 基础运维教程 ==========
+  {
+    title: 'FastGPT 更新日志',
+    desc: '查看 FastGPT 最新版本更新内容，了解新功能、优化改进和问题修复。',
+    url: 'https://doc.fastgpt.cn/zh-CN/self-host/upgrading',
+    level: 'beginner',
+    category: 'operations',
+    type: 'doc'
+  },
+
+  // ========== 行业应用案例 - 企业通用服务 ==========
+  {
+    title: '企业通用服务案例-人力资源部',
+    desc: '人力资源部门如何利用 FastGPT 实现简历筛选、员工咨询和培训管理的智能化。',
+    url: 'https://www.bilibili.com/video/BV16UPfzbECs/',
+    level: 'beginner',
+    category: 'industry-cases',
+    series: '企业案例'
+  },
+  {
+    title: '企业通用服务案例-法务部',
+    desc: '法务部门使用 FastGPT 进行合同审查、法律咨询和风险预警的实践案例。',
+    url: 'https://www.bilibili.com/video/BV1PcPfzaEHk/',
+    level: 'beginner',
+    category: 'industry-cases',
+    series: '企业案例'
+  },
+  {
+    title: '企业通用服务案例-办公效率',
+    desc: '通过 FastGPT 提升办公效率，实现会议纪要生成、邮件自动回复等智能办公场景。',
+    url: 'https://www.bilibili.com/video/BV1eWNczWEsR/',
+    level: 'beginner',
+    category: 'industry-cases',
+    series: '企业案例'
+  },
+  {
+    title: '企业通用服务案例-财务部',
+    desc: '财务部门利用 FastGPT 实现报销审核、财务咨询和数据分析的智能化应用。',
+    url: 'https://www.bilibili.com/video/BV1VCNFzQEmq/',
+    level: 'beginner',
+    category: 'industry-cases',
+    series: '企业案例'
+  },
+  {
+    title: '企业通用服务案例-采购部',
+    desc: '采购部门使用 FastGPT 优化供应商管理、询价比价和采购流程的案例分享。',
+    url: 'https://www.bilibili.com/video/BV12ZNFz3EeR/',
+    level: 'beginner',
+    category: 'industry-cases',
+    series: '企业案例'
+  },
+  {
+    title: '企业通用服务案例-数据中心',
+    desc: '数据中心如何借助 FastGPT 实现数据查询、报表生成和数据分析的智能化。',
+    url: 'https://www.bilibili.com/video/BV1ABcfzxEKw/',
+    level: 'intermediate',
+    category: 'industry-cases',
+    series: '企业案例'
+  },
+
+  // ========== 行业应用案例 - 行业案例 ==========
+  {
+    title: '零售&电商场景案例',
+    desc: '零售电商行业利用 FastGPT 实现智能客服、商品推荐和订单处理的实战案例。',
+    url: 'https://www.bilibili.com/video/BV1yGcZzWEJo/',
+    level: 'beginner',
+    category: 'industry-cases',
+    series: '行业案例'
+  },
+  {
+    title: '医疗健康案例-Neutriva健康服务推荐助手',
+    desc: '医疗健康领域使用 FastGPT 构建智能健康咨询和服务推荐系统的成功案例。',
+    url: 'https://www.bilibili.com/video/BV19ZcfzrEuX/',
+    level: 'intermediate',
+    category: 'industry-cases',
+    series: '行业案例'
+  },
+  {
+    title: '金融服务案例-AI金融日报助手',
+    desc: '金融行业利用 FastGPT 实现金融资讯聚合、市场分析和投资建议的智能助手。',
+    url: 'https://www.bilibili.com/video/BV1qXcBzsErh/',
+    level: 'intermediate',
+    category: 'industry-cases',
+    series: '行业案例'
+  },
+  {
+    title: '教育培训场景案例',
+    desc: '教育培训机构使用 FastGPT 打造智能答疑、学习规划和课程推荐系统。',
+    url: 'https://www.bilibili.com/video/BV1jGcBzXEsQ/',
+    level: 'beginner',
+    category: 'industry-cases',
+    series: '行业案例'
+  },
+  {
+    title: '媒体运营场景案例',
+    desc: '媒体运营团队利用 FastGPT 实现内容创作、舆情监控和粉丝互动的智能化。',
+    url: 'https://www.bilibili.com/video/BV1jAcCzPETb/',
+    level: 'beginner',
+    category: 'industry-cases',
+    series: '行业案例'
+  },
+  {
+    title: '制造业场景案例',
+    desc: '制造业企业使用 FastGPT 实现生产管理、质量检测和设备维护的智能化应用。',
+    url: 'https://www.bilibili.com/video/BV18kc2zPE4R/',
+    level: 'intermediate',
+    category: 'industry-cases',
+    series: '行业案例'
+  },
+
+  // ========== 客户案例 ==========
+  {
+    title: '客户案例集锦',
+    desc: '查看更多 FastGPT 客户的成功案例和应用场景，获取灵感和最佳实践参考。',
+    url: 'https://www.canva.com/design/DAG7qTZT_IQ/2SHmfMyd7IE5KTx-qqdKvg/view',
+    level: 'beginner',
+    category: 'customer-cases',
+    type: 'doc'
+  },
+
+  // ========== 节点介绍 ==========
+  {
+    title: '【节点介绍】AI对话节点',
+    desc: '掌握AI对话节点的功能',
+    url: 'https://www.bilibili.com/video/BV1pQwDzqEdP/',
+    level: 'beginner',
+    category: 'technical-tutorial'
+  },
+  {
+    title: '【节点介绍】文本内容提取',
+    desc: '了解如何使用文本内容提取节点',
+    url: 'https://www.bilibili.com/video/BV1t4w9zHEJh/',
+    level: 'beginner',
+    category: 'technical-tutorial'
+  },
+  {
+    title: '【节点介绍】工具参数配置',
+    desc: '工具参数配置节点如何使用',
+    url: 'https://www.bilibili.com/video/BV1kZwXz3EYU/',
+    level: 'beginner',
+    category: 'technical-tutorial'
+  },
+  {
+    title: '【节点介绍】用户选择节点',
+    desc: '介绍用户选择节点的使用',
+    url: 'https://www.bilibili.com/video/BV1gPwCz4ET9/',
+    level: 'beginner',
+    category: 'technical-tutorial'
+  },
+  {
+    title: '【节点介绍】表单输入节点',
+    desc: '介绍表单输入节点的功能',
+    url: 'https://www.bilibili.com/video/BV1YowkzwEep/',
+    level: 'beginner',
+    category: 'technical-tutorial'
+  },
+  {
+    title: '【节点介绍】指定回复节点',
+    desc: '介绍指定回复节点的功能',
+    url: 'https://www.bilibili.com/video/BV1nkwkzrEw2/',
+    level: 'beginner',
+    category: 'technical-tutorial'
+  },
+  {
+    title: '【节点介绍】文档解析节点',
+    desc: '介绍文档解析节点的功能',
+    url: 'https://www.bilibili.com/video/BV1mGw1zfEsX/',
+    level: 'beginner',
+    category: 'technical-tutorial'
+  },
+  {
+    title: '【节点介绍】HTTP请求节点',
+    desc: 'HTTP请求节点功能介绍',
+    url: 'https://www.bilibili.com/video/BV18WAjzQEb7/?spm_id_from=333.1387.homepage.video_card.click',
+    level: 'beginner',
+    category: 'technical-tutorial'
+  },
+  {
+    title: '【节点介绍】判断器节点',
+    desc: '判断器节点功能介绍',
+    url: 'https://www.bilibili.com/video/BV1GwAJzeEd6/',
+    level: 'beginner',
+    category: 'technical-tutorial'
+  },
+  {
+    title: '【节点介绍】变量更新节点',
+    desc: '介绍变量更新节点的功能',
+    url: 'https://www.bilibili.com/video/BV1YnAEzhEeK/',
+    level: 'beginner',
+    category: 'technical-tutorial'
+  },
+  {
+    title: '【节点介绍】代码运行节点',
+    desc: '代码运行节点功能介绍',
+    url: 'https://www.bilibili.com/video/BV1JXAnzEEza/',
+    level: 'beginner',
+    category: 'technical-tutorial'
+  },
+  {
+    title: '【节点介绍】代码运行节点场景',
+    desc: '代码运行节点适用场景介绍',
+    url: 'https://www.bilibili.com/video/BV16uAnzmEEf/',
+    level: 'beginner',
+    category: 'technical-tutorial'
+  },
+  {
+    title: '【节点介绍】批量执行节点',
+    desc: '批量执行节点功能介绍',
+    url: 'https://www.bilibili.com/video/BV17AQ9BrEEz/',
+    level: 'beginner',
+    category: 'technical-tutorial'
+  },
+  {
+    title: '【节点介绍】知识库搜索引用合并节点',
+    desc: '知识库搜索引用合并节点功能介绍',
+    url: 'https://www.bilibili.com/video/BV1TaQZBMEiR/',
+    level: 'beginner',
+    category: 'technical-tutorial'
+  },
+  {
+    title: '【节点介绍】问题优化节点',
+    desc: '问题优化节点功能介绍',
+    url: 'https://www.bilibili.com/video/BV19AQBBxEhm/',
+    level: 'beginner',
+    category: 'technical-tutorial'
+  },
+  {
+    title: '【节点介绍】自定义反馈节点',
+    desc: '自定义反馈节点功能介绍',
+    url: 'https://www.bilibili.com/video/BV1PwQqBME3m/',
+    level: 'beginner',
+    category: 'technical-tutorial'
+  },
+  {
+    title: 'FastGPT 运维文档',
+    desc: '升级和日常使用中的问题解决方案',
+    url: 'https://fael3z0zfze.feishu.cn/wiki/ITZDw8tDMikuipkfdImc8ESsnef?from=from_copylink',
+    level: 'beginner',
+    category: 'operations',
+    type: 'doc',
+    featured: true
+  },
+  {
+    title: 'FastGPT V4.15.0 更新介绍',
+    desc: '版本更新介绍',
+    url: 'https://www.bilibili.com/video/BV1fdTF6JEAU/?spm_id_from=333.1387.homepage.video_card.click',
+    level: 'beginner',
+    category: 'feature-intro',
+    featured: true
+  }
+];
+
+export default function VideosPage({
+  locale,
+  navLinks,
+  navCta,
+  footer
+}: {
+  locale: string;
+  navLinks: NavLink[];
+  navCta: NavCta;
+  footer: HomeFooter;
+}) {
+  const [activeCategory, setActiveCategory] = useState<string>('all');
+  const contactUrl = useContactUrl(locale);
+  const videos = staticVideos;
+  const announcement: Announcement = { content: '', enabled: false };
+  const settings: Settings = {
+    heroTitle: 'FastGPT 学习中心',
+    heroDescription:
+      '从入门到精通，系统化学习 FastGPT 的使用技巧、部署方案和最佳实践。所有视频均由官方团队精心制作。',
+    heroBadge: '持续更新中'
+  };
+
+  const filteredVideos =
+    activeCategory === 'all' ? videos : videos.filter((v) => v.category === activeCategory);
+
+  const featuredVideos = videos.filter((v) => v.featured).slice(0, 4);
+
+  const levelText = {
+    beginner: '入门',
+    intermediate: '中级',
+    advanced: '进阶'
+  };
+
+  return (
+    <div className={styles.page}>
+      <HomeThemeFix />
+      <Navbar links={navLinks} t={navCta} locale={locale} publishedLocales={['zh']} />
+      <main className={styles.main}>
+        {/* Hero */}
+        <section className={styles.hero}>
+          <div className={styles.container}>
+            <div className={styles.heroBadge}>
+              <div className={styles.heroBadgeDot}></div>
+              {settings.heroBadge || '持续更新中'} · 已有 {videos.length}+ 个教程
+            </div>
+            <h1>{settings.heroTitle || 'FastGPT 学习中心'}</h1>
+            <p>
+              {settings.heroDescription ||
+                '从入门到精通，系统化学习 FastGPT 的使用技巧、部署方案和最佳实践。所有视频均由官方团队精心制作。'}
+            </p>
+            <div className={styles.heroActions}>
+              <a
+                className={styles.primaryCta}
+                href={contactUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                {...rybbitClickAttrs(
+                  RYBBIT_EVENTS.businessConsultClick,
+                  'learning_center_hero_consult'
+                )}
+              >
+                商务咨询 <span aria-hidden="true">→</span>
+              </a>
+              <Link className={styles.secondaryCta} href="/">
+                了解 FastGPT
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* Banner - Featured Videos & Announcement */}
+        {(announcement.enabled && announcement.content) || featuredVideos.length > 0 ? (
+          <section>
+            <div className={styles.container}>
+              {announcement.enabled && announcement.content && (
+                <div className={styles.announcement}>
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  >
+                    <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                    <line x1="12" y1="9" x2="12" y2="13" />
+                    <line x1="12" y1="17" x2="12.01" y2="17" />
+                  </svg>
+                  <span>{announcement.content}</span>
+                </div>
+              )}
+
+              {featuredVideos.length > 0 && (
+                <div className={styles.featuredSection}>
+                  <h2 className={styles.featuredTitle}>
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+                    </svg>
+                    推荐视频
+                  </h2>
+                  <div className={styles.featuredGrid}>
+                    {featuredVideos.map((video, index) => {
+                      const isDoc = video.type === 'doc';
+                      return (
+                        <a
+                          key={video._id || index}
+                          href={video.url}
+                          className={styles.featuredCard}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <div
+                            className={`${styles.featuredThumb} ${isDoc ? styles.docThumb : ''}`}
+                          >
+                            <VideoCover video={video} compact />
+                            <div className={styles.featuredOverlay}>
+                              <div className={styles.featuredPlayBtn}>
+                                {isDoc ? (
+                                  <svg
+                                    width="20"
+                                    height="20"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    strokeWidth="2"
+                                  >
+                                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                                    <polyline points="14 2 14 8 20 8" />
+                                    <line x1="16" y1="13" x2="8" y2="13" />
+                                    <line x1="16" y1="17" x2="8" y2="17" />
+                                  </svg>
+                                ) : (
+                                  <svg
+                                    width="20"
+                                    height="20"
+                                    viewBox="0 0 24 24"
+                                    fill="currentColor"
+                                  >
+                                    <polygon points="5 3 19 12 5 21 5 3" />
+                                  </svg>
+                                )}
+                              </div>
+                            </div>
+                          </div>
+                          <div className={styles.featuredInfo}>
+                            <h3>{video.title}</h3>
+                            <p>{video.desc}</p>
+                          </div>
+                        </a>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
+          </section>
+        ) : null}
+
+        {/* Videos */}
+        <section>
+          <div className={styles.container}>
+            <div className={styles.videoCategories}>
+              <button
+                className={`${styles.videoCatBtn} ${activeCategory === 'all' ? styles.active : ''}`}
+                onClick={() => setActiveCategory('all')}
+              >
+                全部
+              </button>
+              <button
+                className={`${styles.videoCatBtn} ${
+                  activeCategory === 'beginner-tutorial' ? styles.active : ''
+                }`}
+                onClick={() => setActiveCategory('beginner-tutorial')}
+              >
+                新手教学
+              </button>
+              <button
+                className={`${styles.videoCatBtn} ${
+                  activeCategory === 'technical-tutorial' ? styles.active : ''
+                }`}
+                onClick={() => setActiveCategory('technical-tutorial')}
+              >
+                技术教学教程
+              </button>
+              <button
+                className={`${styles.videoCatBtn} ${
+                  activeCategory === 'deployment' ? styles.active : ''
+                }`}
+                onClick={() => setActiveCategory('deployment')}
+              >
+                部署教程
+              </button>
+              <button
+                className={`${styles.videoCatBtn} ${
+                  activeCategory === 'feature-intro' ? styles.active : ''
+                }`}
+                onClick={() => setActiveCategory('feature-intro')}
+              >
+                功能介绍
+              </button>
+              <button
+                className={`${styles.videoCatBtn} ${
+                  activeCategory === 'operations' ? styles.active : ''
+                }`}
+                onClick={() => setActiveCategory('operations')}
+              >
+                基础运维教程
+              </button>
+              <button
+                className={`${styles.videoCatBtn} ${
+                  activeCategory === 'industry-cases' ? styles.active : ''
+                }`}
+                onClick={() => setActiveCategory('industry-cases')}
+              >
+                行业应用案例
+              </button>
+              <button
+                className={`${styles.videoCatBtn} ${
+                  activeCategory === 'customer-cases' ? styles.active : ''
+                }`}
+                onClick={() => setActiveCategory('customer-cases')}
+              >
+                客户案例
+              </button>
+            </div>
+
+            <div className={styles.videoGrid}>
+              {filteredVideos.length === 0 ? (
+                <div className={styles.emptyState}>
+                  <div className={styles.emptyStateIcon}>
+                    <svg
+                      width="64"
+                      height="64"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                    >
+                      <polygon points="23 7 16 12 23 17 23 7" />
+                      <rect x="1" y="5" width="15" height="14" rx="2" ry="2" />
+                    </svg>
+                  </div>
+                  <div className={styles.emptyStateText}>该分类暂无视频内容</div>
+                </div>
+              ) : (
+                filteredVideos.map((video, index) => {
+                  const isDoc = video.type === 'doc';
+                  return (
+                    <a
+                      key={index}
+                      href={video.url}
+                      className={styles.videoCard}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <div className={`${styles.videoThumb} ${isDoc ? styles.docThumb : ''}`}>
+                        <VideoCover video={video} compact />
+                        <div className={styles.videoPlayOverlay}>
+                          <div className={styles.videoPlayBtn}>
+                            {isDoc ? (
+                              <svg
+                                width="20"
+                                height="20"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                              >
+                                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                                <polyline points="14 2 14 8 20 8" />
+                                <line x1="16" y1="13" x2="8" y2="13" />
+                                <line x1="16" y1="17" x2="8" y2="17" />
+                                <polyline points="10 9 9 9 8 9" />
+                              </svg>
+                            ) : (
+                              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                                <polygon points="5 3 19 12 5 21 5 3" />
+                              </svg>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                      <div className={styles.videoInfo}>
+                        <h3>{video.title}</h3>
+                        <p className={styles.videoDesc}>{video.desc}</p>
+                        <div className={styles.videoInfoMeta}>
+                          <span
+                            className={`${styles.videoLevel} ${
+                              styles[
+                                `level${video.level.charAt(0).toUpperCase() + video.level.slice(1)}`
+                              ]
+                            }`}
+                          >
+                            {levelText[video.level]}
+                          </span>
+                        </div>
+                      </div>
+                    </a>
+                  );
+                })
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.leadCta} aria-label="商务咨询">
+          <div className={styles.container}>
+            <div className={styles.leadCtaInner}>
+              <div>
+                <span className={styles.leadCtaEyebrow}>FastGPT 商务支持</span>
+                <h2>想把 AI 应用真正落地？</h2>
+                <p>留下需求和联系方式，FastGPT 团队会为你提供架构建议与 POC 支持。</p>
+              </div>
+              <a
+                className={styles.primaryCta}
+                href={contactUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                {...rybbitClickAttrs(
+                  RYBBIT_EVENTS.businessConsultClick,
+                  'learning_center_cta_consult'
+                )}
+              >
+                开始咨询 <span aria-hidden="true">→</span>
+              </a>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer t={footer} locale={locale} />
+    </div>
+  );
+}

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -10,7 +10,7 @@
     },
     {
       "label": "学习中心",
-      "href": "https://video.fastgpt.cn/videos"
+      "href": "/videos"
     },
     {
       "label": "案例中心",
@@ -426,6 +426,30 @@
       "subtitle": "即刻尝试",
       "trial": "立即开始",
       "consult": "商务咨询"
+    },
+    "consultationDialog": {
+      "badge": "FastGPT 企业服务",
+      "title": "FastGPT 商务咨询",
+      "description": "留下你的业务流程、数据现状与目标效果，FastGPT 团队将在 1 天内联系你，结合知识库、工作流与智能体能力，为你提供一份可落地的专属方案。",
+      "benefits": [
+        {
+          "title": "从知识库到 AI 应用",
+          "description": "基于企业知识库与 RAG，快速构建可信的业务问答。"
+        },
+        {
+          "title": "用工作流编排业务流程",
+          "description": "可视化工作流连接模型、知识库与业务系统。"
+        },
+        {
+          "title": "构建可运营的智能体",
+          "description": "围绕真实业务场景，让 AI 持续落地执行。"
+        },
+        {
+          "title": "支持企业级部署与治理",
+          "description": "覆盖 SaaS 与私有化，满足企业安全要求。"
+        }
+      ],
+      "footer": "已服务金融、制造、教育、医疗等 17 个重点行业"
     },
     "footer": {
       "tagline": "企业级AI生产力引擎",


### PR DESCRIPTION
将 FastGPT 学习中心及预览修复同步到 labring/fastgpt-home。

主要变更：
- 新增静态 /videos 学习中心页面，复用现有 Navbar、Footer 和 HomeThemeFix。
- 仅在中文站生成学习中心，canonical、导航和 sitemap 对齐。
- 修正重复部署视频、封面系列序号、Canva 编辑链接和更新日志入口。
- 清理重复页头页脚样式与冗余资产。
- 新增 verify:learning-center 静态链接校验。

验证已通过：npm run lint、npx tsc --noEmit、npm run verify:learning-center、npm run build。